### PR TITLE
Fix mixed-dimension Point.distance (swev-id: sympy__sympy-11618)

### DIFF
--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -266,8 +266,19 @@ class Point(GeometryEntity):
         sqrt(x**2 + y**2)
 
         """
-        return sqrt(sum([(a - b)**2 for a, b in zip(
-            self.args, p.args if isinstance(p, Point) else p)]))
+        if not isinstance(p, Point):
+            p = Point(p)
+        a = self.args
+        b = p.args
+        la = len(a)
+        lb = len(b)
+        n = la if la >= lb else lb
+        total = S.Zero
+        for i in range(n):
+            ai = a[i] if i < la else S.Zero
+            bi = b[i] if i < lb else S.Zero
+            total += (ai - bi)**2
+        return sqrt(total)
 
     def taxicab_distance(self, p):
         """The Taxicab Distance from self to point p.

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -10,6 +10,7 @@ from sympy.utilities.pytest import raises
 def test_point():
     x = Symbol('x', real=True)
     y = Symbol('y', real=True)
+    z = Symbol('z', real=True)
     x1 = Symbol('x1', real=True)
     x2 = Symbol('x2', real=True)
     y1 = Symbol('y1', real=True)
@@ -41,6 +42,11 @@ def test_point():
     assert Point.distance(p3, p4) == sqrt(2)
     assert Point.distance(p1, p1) == 0
     assert Point.distance(p3, p2) == sqrt(p2.x**2 + p2.y**2)
+    assert Point(2, 0).distance(Point(1, 0, 2)) == sqrt(5)
+    assert Point(0, 0).distance(Point(0, 0, 0)) == 0
+    assert Point(x, 0).distance(Point(0, 0, z)) == sqrt(x**2 + z**2)
+    assert Point(1, 1).distance(Point(4, 5)) == 5
+    assert Point(0, 0, 0).distance(Point(1, 1, 1)) == sqrt(3)
 
     assert Point.taxicab_distance(p4, p3) == 2
 


### PR DESCRIPTION
## Summary
- pad Point.distance to include missing coordinates as zeros for Euclidean distance
- expand point distance tests to cover mixed dimensions and symbolic cases

## Testing
- PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH python -m pytest sympy/geometry/tests/test_point.py
- PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test code_quality

Fixes #13