### PR TITLE
fix: swev-id: sympy__sympy-12096 propagate implemented_function evalf

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -42,7 +42,7 @@ from .numbers import Rational, Float
 from .operations import LatticeOp
 from .rules import Transform
 from .singleton import S
-from .sympify import sympify
+from .sympify import sympify, SympifyError
 
 from sympy.core.containers import Tuple, Dict
 from sympy.core.logic import fuzzy_and
@@ -506,10 +506,25 @@ class Function(Application, Expr):
                 fname = MPMATH_TRANSLATIONS[fname]
             func = getattr(mpmath, fname)
         except (AttributeError, KeyError):
-            try:
-                return Float(self._imp_(*self.args), prec)
-            except (AttributeError, TypeError, ValueError):
+            imp = getattr(self, '_imp_', None)
+            if imp is None:
                 return
+            dps = mlib.libmpf.prec_to_dps(prec)
+            evalf_args = [a if a.is_number else a.evalf(dps)
+                          for a in self.args]
+            if not all(arg.is_number for arg in evalf_args):
+                return
+            try:
+                res = imp(*evalf_args)
+            except (TypeError, ValueError):
+                return
+            try:
+                return sympify(res).evalf(dps)
+            except (TypeError, ValueError, AttributeError, SympifyError):
+                try:
+                    return Float(res, dps)
+                except (TypeError, ValueError):
+                    return
 
         # Convert all args to mpf or mpc
         # Convert the arguments to *higher* precision than requested for the

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -328,6 +328,45 @@ def test_implemented_function_evalf():
     del f._imp_     # XXX: due to caching _imp_ would influence all other tests
 
 
+def test_implemented_function_evalf_composition():
+    from sympy.utilities.lambdify import implemented_function
+    f = Function('f_comp')
+    g = Function('g_comp')
+    f = implemented_function(f, lambda x: x**2)
+    g = implemented_function(g, lambda x: 2*x)
+    try:
+        assert f(g(2)).evalf() == 16
+    finally:
+        for func in (f, g):
+            if hasattr(func, '_imp_'):
+                del func._imp_
+
+
+def test_implemented_function_evalf_precision():
+    from sympy.utilities.lambdify import implemented_function
+    f = Function('f_prec')
+    g = Function('g_prec')
+    f = implemented_function(f, lambda x: x**2)
+    g = implemented_function(g, lambda x: 2*x)
+    try:
+        assert f(g(pi)).evalf(50) == (4*pi**2).evalf(50)
+    finally:
+        for func in (f, g):
+            if hasattr(func, '_imp_'):
+                del func._imp_
+
+
+def test_implemented_function_evalf_complex():
+    from sympy.utilities.lambdify import implemented_function
+    h = Function('h_complex')
+    h = implemented_function(h, lambda x: 1j*x)
+    try:
+        assert h(2).evalf() == 2*I
+    finally:
+        if hasattr(h, '_imp_'):
+            del h._imp_
+
+
 def test_evaluate_false():
     for no in [0, False]:
         assert Add(3, 2, evaluate=no).is_Add


### PR DESCRIPTION
## Issue
- Closes #15

## Observed Failure
1. `from sympy.utilities.lambdify import implemented_function`
2. `f = implemented_function('f', lambda x: x**2)`
3. `g = implemented_function('g', lambda x: 2*x)`
4. `f(g(2)).evalf()` returns `f(g(2))` instead of evaluating numerically.

## Summary
- route Function `_imp_` evalf fallback through the implementation when no mpmath equivalent exists
- evaluate arguments with the requested precision and propagate precision to the result
- add regression tests covering composition, precision propagation, and complex results

## Testing
- `PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH python -m pytest sympy/core/tests/test_evalf.py -k implemented_function`
- `PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH bin/test code_quality`