### PR TITLE
swev-id: sympy__sympy-12481 - Accept overlapping cycles in Permutation

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -895,12 +895,8 @@ class Permutation(Basic):
         # counting starts from 1.
 
         temp = flatten(args)
-        if has_dups(temp):
-            if is_cycle:
-                raise ValueError('there were repeated elements; to resolve '
-                'cycles use Cycle%s.' % ''.join([str(tuple(c)) for c in args]))
-            else:
-                raise ValueError('there were repeated elements.')
+        if not is_cycle and has_dups(temp):
+            raise ValueError('there were repeated elements.')
         temp = set(temp)
 
         if not is_cycle and \

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -522,12 +522,12 @@ class Permutation(Basic):
     >>> [p(q(i)) for i in range(p.size)]
     [1, 2, 0]
 
-    Disjoint Cycle Notation
-    -----------------------
+    Cycle Notation
+    --------------
 
-    In disjoint cycle notation, only the elements that have shifted are
-    indicated. In the above case, the 2 and 1 switched places. This can
-    be entered in two ways:
+    In cycle notation, only the elements that have shifted are indicated.
+    In the above case, the 2 and 1 switched places. This can be entered in
+    two ways:
 
     >>> Permutation(1, 2) == Permutation([[1, 2]]) == p
     True
@@ -537,19 +537,24 @@ class Permutation(Basic):
     >>> Permutation(1,2,3) == Permutation(2,3,1) == Permutation(3,1,2)
     True
 
-    The disjoint cycle notation is convenient when representing permutations
-    that have several cycles in them:
+    Cycle notation is convenient when representing permutations that have
+    several cycles in them:
 
     >>> Permutation(1, 2)(3, 5) == Permutation([[1, 2], [3, 5]])
     True
 
     It also provides some economy in entry when computing products of
-    permutations that are written in disjoint cycle notation:
+    permutations that are written in cycle notation:
 
     >>> Permutation(1, 2)(1, 3)(2, 3)
     Permutation([0, 3, 2, 1])
     >>> _ == Permutation([[1, 2]])*Permutation([[1, 3]])*Permutation([[2, 3]])
     True
+
+    Cycles supplied to ``Permutation`` need not be disjoint. When successive
+    cycles share elements, they are composed left-to-right, just as repeated
+    ``Cycle`` calls would be. Symbols may not repeat within a single cycle,
+    however; doing so still raises a ``ValueError``.
 
     Entering a singleton in a permutation is a way to indicate the size of the
     permutation. The ``size`` keyword can also be used.

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -349,7 +349,12 @@ def test_args():
     raises(ValueError, lambda: Permutation([[1, 2], 0]))
            # enclosing brackets needed on 0
     raises(ValueError, lambda: Permutation([1, 1, 0]))
-    raises(ValueError, lambda: Permutation([[1], [1, 2]]))
+    assert Permutation([[1], [1, 2]]) == Permutation([0, 2, 1])
+    assert Permutation([[0, 1], [0, 1]]) == Permutation([0, 1])
+    assert Permutation([[0, 1], [1, 2]]) == Permutation([2, 0, 1])
+    assert Permutation([[0, 1, 2], [2, 1]]) == Permutation([2, 1, 0])
+    assert Permutation([[1], [1], [1, 2]]) == Permutation([0, 2, 1])
+    assert Permutation([[5, 6], [5, 6]]) == Permutation([0, 1, 2, 3, 4, 5, 6])
     raises(ValueError, lambda: Permutation([4, 5], size=10))  # where are 0-3?
     # but this is ok because cycles imply that only those listed moved
     assert Permutation(4, 5) == Permutation([0, 1, 2, 3, 5, 4])


### PR DESCRIPTION
## Summary
- allow cycle-form Permutation inputs to reuse symbols across cycles
- keep array-form duplicate detection intact while relying on Cycle composition for ordering
- cover overlapping cycle compositions with targeted regression tests

## Testing
- PATH=/root/.local/bin:$PATH PYTHONPATH=/workspace/pythoncompat:/workspace/sympy python -m pytest sympy/combinatorics/tests/test_permutations.py -q
- PATH=/root/.local/bin:$PATH PYTHONPATH=/workspace/pythoncompat:/workspace/sympy python bin/test code_quality

## Pre-change reproduction
1. PATH=/root/.local/bin:$PATH PYTHONPATH=/workspace/pythoncompat:/workspace/sympy /usr/local/bin/python - <<'PY'
from sympy.combinatorics.permutations import Permutation
Permutation([[0, 1], [0, 1]])
PY

```
/workspace/sympy/sympy/external/importtools.py:5: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.version import StrictVersion
/workspace/sympy/sympy/solvers/diophantine.py:3188: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if feasible is 1:  # it's prime and k == 2
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/workspace/sympy/sympy/combinatorics/permutations.py", line 900, in __new__
    raise ValueError('there were repeated elements; to resolve '
ValueError: there were repeated elements; to resolve cycles use Cycle%s.
```

Fixes #18.