### PR TITLE
swev-id: sympy__sympy-12489 fix Permutation subclassing

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -857,19 +857,19 @@ class Permutation(Basic):
         #g) (Permutation) = adjust size or return copy
         ok = True
         if not args:  # a
-            return _af_new(list(range(size or 0)))
+            return cls._af_new(list(range(size or 0)))
         elif len(args) > 1:  # c
-            return _af_new(Cycle(*args).list(size))
+            return cls._af_new(Cycle(*args).list(size))
         if len(args) == 1:
             a = args[0]
             if isinstance(a, Perm):  # g
                 if size is None or size == a.size:
                     return a
-                return Perm(a.array_form, size=size)
+                return cls(a.array_form, size=size)
             if isinstance(a, Cycle):  # f
-                return _af_new(a.list(size))
+                return cls._af_new(a.list(size))
             if not is_sequence(a):  # b
-                return _af_new(list(range(a + 1)))
+                return cls._af_new(list(range(a + 1)))
             if has_variety(is_sequence(ai) for ai in a):
                 ok = False
         else:
@@ -924,8 +924,8 @@ class Permutation(Basic):
         obj._size = size
         return obj
 
-    @staticmethod
-    def _af_new(perm):
+    @classmethod
+    def _af_new(cls, perm):
         """A method to produce a Permutation object from a list;
         the list is bound to the _array_form attribute, so it must
         not be modified; this method is meant for internal use only;
@@ -944,7 +944,7 @@ class Permutation(Basic):
         Permutation([2, 1, 3, 0])
 
         """
-        p = Basic.__new__(Perm, perm)
+        p = Basic.__new__(cls, perm)
         p._array_form = perm
         p._size = len(perm)
         return p

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -217,6 +217,17 @@ def test_Permutation():
     assert b.cycle_structure == {2: 1, 3: 1, 1: 2}
 
 
+def test_permutation_subclass_construction():
+    class MyPerm(Permutation):
+        pass
+
+    assert isinstance(MyPerm(), MyPerm)
+    assert isinstance(MyPerm(1, 2), MyPerm)
+    assert isinstance(MyPerm(Cycle(1, 2)), MyPerm)
+    assert isinstance(MyPerm(Permutation([0, 1]), size=3), MyPerm)
+    assert isinstance(MyPerm([0, 1]), MyPerm)
+
+
 def test_josephus():
     assert Permutation.josephus(4, 6, 1) == Permutation([3, 1, 0, 2, 5, 4])
     assert Permutation.josephus(1, 5, 1).is_Identity


### PR DESCRIPTION
## Summary
- convert `Permutation._af_new` into a classmethod so subclass construction uses the dynamic type
- update `Permutation.__new__` to route through `cls._af_new`/`cls(...)` and keep legacy aliases intact
- add a regression test ensuring every supported constructor path returns subclass instances

## Reproduction
```python
from sympy.combinatorics.permutations import Permutation, Cycle
class MyPerm(Permutation):
    pass

assert isinstance(MyPerm(), MyPerm)
assert isinstance(MyPerm(1, 2), MyPerm)
assert isinstance(MyPerm(Cycle(1, 2)), MyPerm)
assert isinstance(MyPerm(Permutation([0, 1]), size=3), MyPerm)
assert isinstance(MyPerm([0, 1]), MyPerm)
```

## Notes
- Python 3.9 is unavailable in the current nixpkgs channel on aarch64. Tests ran under Python 3.10 with a `sitecustomize` shim restoring legacy `collections` names required by this historical SymPy snapshot.

## Testing
- PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH python bin/test sympy/combinatorics
- PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH python bin/test sympy/tensor
- PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH python bin/test code_quality

Closes #22