### PR TITLE
swev-id: sympy__sympy-13031 fix sparse zero-dim joins

### DIFF
--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -985,7 +985,7 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
         >>> C == A.row_insert(A.rows, Matrix(B))
         True
         """
-        if not self:
+        if self.rows == 0:
             return type(self)(other)
         A, B = self, other
         if not A.cols == B.cols:
@@ -1191,7 +1191,7 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
         >>> C == A.col_insert(A.cols, B)
         True
         """
-        if not self:
+        if self.cols == 0:
             return type(self)(other)
         A, B = self, other
         if not A.rows == B.rows:

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -2,6 +2,17 @@ from sympy import Abs, S, Symbol, I, Rational, PurePoly
 from sympy.matrices import Matrix, SparseMatrix, eye, zeros, ShapeError
 from sympy.utilities.pytest import raises
 
+
+def test_sparse_hstack_vstack_zero_dim():
+    zero_row_matrices = [SparseMatrix.zeros(0, n) for n in range(4)]
+    assert SparseMatrix.hstack(*zero_row_matrices).shape == (0, 6)
+
+    zero_col_matrices = [SparseMatrix.zeros(n, 0) for n in range(4)]
+    assert SparseMatrix.vstack(*zero_col_matrices).shape == (6, 0)
+
+    assert SparseMatrix.zeros(0, 2).row_join(Matrix.zeros(0, 3)).shape == (0, 5)
+    assert SparseMatrix.zeros(2, 0).col_join(Matrix.zeros(3, 0)).shape == (5, 0)
+
 def test_sparse_matrix():
     def sparse_eye(n):
         return SparseMatrix.eye(n)


### PR DESCRIPTION
## Reproduction
```bash
PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH python3 -m pytest sympy/matrices/tests/test_sparse.py::test_sparse_hstack_vstack_zero_dim -vv
```

## Observed failure
```
============================= test session starts ==============================
platform linux -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0 -- /root/.nix-profile/bin/python3
cachedir: .pytest_cache
architecture: 64-bit
cache:        yes
ground types: python 

rootdir: /workspace/sympy
collecting ... collected 1 item

sympy/matrices/tests/test_sparse.py::test_sparse_hstack_vstack_zero_dim FAILED [100%]

=================================== FAILURES ===================================
______________________ test_sparse_hstack_vstack_zero_dim ______________________

    def test_sparse_hstack_vstack_zero_dim():
        zero_row_matrices = [SparseMatrix.zeros(0, n) for n in range(4)]
>       assert SparseMatrix.hstack(*zero_row_matrices).shape == (0, 6)
E       assert (0, 3) == (0, 6)
E         
E         At index 1 diff: 3 != 6
E         
E         Full diff:
E           (
E               0,
E         -     6,
E         ?     ^
E         +     3,
E         ?     ^
E           )

sympy/matrices/tests/test_sparse.py:8: AssertionError
=============================== warnings summary ===============================
sympy/external/importtools.py:5
  /workspace/sympy/sympy/external/importtools.py:5: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils.version import StrictVersion

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
                                DO *NOT* COMMIT!                                
=========================== short test summary info ============================
FAILED sympy/matrices/tests/test_sparse.py::test_sparse_hstack_vstack_zero_dim - assert (0, 3) == (0, 6)
  
  At index 1 diff: 3 != 6
  
  Full diff:
    (
        0,
  -     6,
  ?     ^
  +     3,
  ?     ^
    )
========================= 1 failed, 1 warning in 0.03s =========================
```

## Fix
- treat zero-row sparse matrices as identity for `col_join`
- treat zero-column sparse matrices as identity for `row_join`
- add regression coverage for sparse/dense zero-dimension stacks

## Verification
```bash
PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH python3 -m pytest sympy/matrices/tests/test_sparse.py::test_sparse_hstack_vstack_zero_dim -vv
PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH ./bin/test code_quality
```

Fixes #23
