### PR TITLE
Fix NameError in coth.eval during subs on coth(log(tan(x))) (swev-id: sympy__sympy-13480)

### DIFF
--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -587,7 +587,7 @@ class coth(HyperbolicFunction):
                 x, m = _peeloff_ipi(arg)
                 if m:
                     cothm = coth(m)
-                    if cotm is S.ComplexInfinity:
+                    if cothm is S.ComplexInfinity:
                         return coth(x)
                     else: # cothm == 0
                         return tanh(x)

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -883,6 +883,29 @@ def test_coth_rewrite():
     assert coth(x).rewrite(tanh) == 1/tanh(x)
 
 
+def test_coth_log_tan_integer_subs_branch():
+    x = Symbol('x')
+    expr = coth(log(tan(x)))
+
+    historical = [2, 3, 5, 6, 8, 9, 11, 12, 15, 18]
+    positive_tan = [4, 7, 10, 13, 16]
+
+    for value in historical + positive_tan:
+        evaluated = expr.subs(x, value)
+        assert evaluated.func == coth
+
+
+def test_coth_additive_ipi_handling():
+    z = Symbol('z')
+    m = Symbol('m', integer=True)
+    expr = coth(z + m*pi*I/2)
+
+    assert expr.subs(m, 0) == coth(z)
+
+    for value in [1, -1, 3]:
+        assert expr.subs(m, value) == tanh(z)
+
+
 def test_csch_rewrite():
     x = Symbol('x')
     assert csch(x).rewrite(exp) == 1 / (exp(x)/2 - exp(-x)/2) \


### PR DESCRIPTION
## Issue
- Fixes #28

## Reproduction
1. Open a SymPy shell.
2. Run:
   ```python
   from sympy import symbols, coth, log, tan
   x = symbols('x')
   coth(log(tan(x))).subs(x, 2)
   ```
- Observed: `NameError: name 'cotm' is not defined`.

## Fix
- Rename the temporary `cotm` variable to `cothm` inside `coth.eval`.
- Add regression coverage for `coth(log(tan(x)))` substitutions and additive `I*pi` handling.

## Testing
- `PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH python3 -m pytest sympy/functions/elementary/tests/test_hyperbolic.py`
- `PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH bin/test code_quality`