### PR TITLE
fix: correct dense col_insert shift (swev-id: sympy__sympy-13647)

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -86,7 +86,7 @@ class MatrixShaping(MatrixRequired):
                 return self[i, j]
             elif pos <= j < pos + other.cols:
                 return other[i, j - pos]
-            return self[i, j - pos - other.cols]
+            return self[i, j - other.cols]
 
         return self._new(self.rows, self.cols + other.cols,
                          lambda i, j: entry(i, j))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2235,6 +2235,33 @@ def test_col_insert():
         assert flatten(zeros(3).col_insert(i, c4).row(0).tolist()) == l
 
 
+def test_col_insert_dense_regressions():
+    m = eye(6)
+    v = 2*ones(6, 2)
+    r = m.col_insert(3, v)
+    assert r.shape == (6, 8)
+    assert r[:, :3] == m[:, :3]
+    assert r[:, 3:5] == v
+    assert r[:, 5:] == m[:, 3:]
+
+    leading = 7*ones(6, 1)
+    inserted = m.col_insert(0, leading)
+    assert inserted[:, 0] == leading
+    assert inserted[:, 1:] == m
+
+    trailing = -3*ones(6, 1)
+    appended = m.col_insert(m.cols, trailing)
+    assert appended[:, :-1] == m
+    assert appended[:, -1] == trailing
+
+    base = Matrix([[1, 2, 3], [4, 5, 6]])
+    newcol = Matrix([[9], [10]])
+    mid = base.col_insert(1, newcol)
+    assert mid == Matrix([[1, 9, 2, 3], [4, 10, 5, 6]])
+
+    neg = base.col_insert(-1, newcol)
+    assert neg == Matrix([[1, 2, 9, 3], [4, 5, 10, 6]])
+
 def test_normalized():
     assert Matrix([3, 4]).normalized() == \
         Matrix([Rational(3, 5), Rational(4, 5)])


### PR DESCRIPTION
## Summary
- fix the dense `MatrixShaping._eval_col_insert` column remapping so post-insert columns keep their original indices
- add dense `col_insert` regression coverage for mid/start/end/negative insertion positions

## Root Cause
- the dense `col_insert` path subtracted both `pos` and `other.cols` when forwarding indices to `self`, so columns to the right of the insertion were read too far left whenever `pos > 0`

## Fix
- subtract only `other.cols` when addressing existing columns in `_eval_col_insert`
- add regression checks that exercise inserting multiple and single dense columns across positions

## Reproduction Steps
1. Checkout `sympy__sympy-13647`.
2. Run the new regression test (fails before this patch):
   ```
   python3 -m pytest sympy/matrices/tests/test_matrices.py -k col_insert_dense_regressions
   ```
3. Or reproduce interactively:
   ```
   python3 - <<'PY'
   from sympy import eye, ones
   R = eye(6).col_insert(3, 2*ones(6, 2))
   print(R[:, 5:])
   PY
   ```

## Failing Output (pre-fix)
```
============================= test session starts ==============================
platform linux -- Python 3.10.19, pytest-9.0.2, pluggy-1.6.0
architecture: 64-bit
cache:        yes
ground types: python 

rootdir: /workspace/sympy
collected 158 items / 157 deselected / 1 selected

sympy/matrices/tests/test_matrices.py F                                  [100%]

=================================== FAILURES ===================================
______________________ test_col_insert_dense_regressions _______________________

    def test_col_insert_dense_regressions():
        m = eye(6)
        v = 2*ones(6, 2)
        r = m.col_insert(3, v)
        assert r.shape == (6, 8)
        assert r[:, :3] == m[:, :3]
        assert r[:, 3:5] == v
>       assert r[:, 5:] == m[:, 3:]
E       assert Matrix([
E       [1, ...],
E       [0, 0, 0]]) == Matrix([
E       [0, ...],
E       [0, 0, 1]])
E         
E         Use -v to get more diff

sympy/matrices/tests/test_matrices.py:2245: AssertionError
=============================== warnings summary ===============================
...
================ 1 failed, 157 deselected, 2 warnings in 0.50s =================
```

## Tests Added
- `test_col_insert_dense_regressions` in `sympy/matrices/tests/test_matrices.py`

## Verification
- `PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH python3 -m pytest sympy/matrices/tests/test_matrices.py -k col_insert_dense_regressions`
- `PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH bin/test code_quality`

Fixes #30