### PR TITLE
fix: correct additive product evaluation (swev-id: sympy__sympy-13551)

### DIFF
--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -237,6 +237,7 @@ class Product(ExprWithIntLimits):
         from sympy.concrete.delta import deltaproduct, _has_simple_delta
         from sympy.concrete.summations import summation
         from sympy.functions import KroneckerDelta, RisingFactorial
+        from sympy.functions.special.q_functions import q_pochhammer
 
         (k, a, n) = limits
 
@@ -275,18 +276,60 @@ class Product(ExprWithIntLimits):
             return poly.LC()**(n - a + 1) * A * B
 
         elif term.is_Add:
+            count = n - a + 1
+
+            add_args = term.args
+            k_terms = [arg for arg in add_args if arg.has(k)]
+            if len(k_terms) == 1:
+                k_term = k_terms[0]
+                const_terms = [arg for arg in add_args if not arg.has(k)]
+                if const_terms:
+                    const_term = sum(const_terms, S.Zero)
+
+                    if const_term is not S.Zero and not const_term.has(k):
+                        coeff, power_term = k_term.as_independent(k, as_Add=False)
+                        if not coeff.has(k) and power_term != 1 and power_term.has(k):
+                            base = None
+                            exp = None
+
+                            if power_term.is_Pow:
+                                base = power_term.base
+                                exp = power_term.exp
+                            elif power_term.is_Mul:
+                                ind_coeff, pow_part = power_term.as_independent(k, as_Add=False)
+                                if ind_coeff.has(k):
+                                    pow_part = None
+                                else:
+                                    coeff *= ind_coeff
+                                    power_term = pow_part
+                                    if power_term.is_Pow:
+                                        base = power_term.base
+                                        exp = power_term.exp
+
+                            if base is not None and not base.has(k) and exp is not None:
+                                if exp == k:
+                                    q_base = base
+                                elif exp == -k:
+                                    q_base = base**-1
+                                else:
+                                    q_base = None
+
+                                if q_base is not None and not q_base.has(k):
+                                    return const_term**count * q_pochhammer(-coeff/const_term, q_base, count)
+
             p, q = term.as_numer_denom()
-            q = self._eval_product(q, (k, a, n))
-            if q.is_Number:
+            if p == term:
+                return None
 
-                # There is expression, which couldn't change by
-                # as_numer_denom(). E.g. n**(2/3) + 1 --> (n**(2/3) + 1, 1).
-                # We have to catch this case.
+            q_eval = self._eval_product(q, (k, a, n))
+            if q_eval is None:
+                return None
 
-                p = sum([self._eval_product(i, (k, a, n)) for i in p.as_coeff_Add()])
-            else:
-                p = self._eval_product(p, (k, a, n))
-            return p / q
+            p_eval = self._eval_product(p, (k, a, n))
+            if p_eval is None:
+                return None
+
+            return p_eval / q_eval
 
         elif term.is_Mul:
             exclude, include = [], []

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -2,8 +2,10 @@ from sympy import (symbols, Symbol, product, factorial, rf, sqrt, cos,
                    Function, Product, Rational, Sum, oo, exp, log, S)
 from sympy.utilities.pytest import raises
 from sympy import simplify
+from sympy.functions.special.q_functions import q_pochhammer
 
 a, k, n, m, x = symbols('a,k,n,m,x', integer=True)
+b, q = symbols('b q')
 f = Function('f')
 
 
@@ -215,6 +217,30 @@ def test_multiple_products():
 
 def test_rational_products():
     assert product(1 + 1/k, (k, 1, n)) == rf(2, n)/factorial(n)
+
+
+def test_product_additive_geometric_rule():
+    expr = Product(n + 1/2**k, (k, 0, n - 1)).doit()
+    expected = n**n * q_pochhammer(-S.One/n, S.Half, n)
+    assert simplify(expr/expected) == 1
+
+    for value in range(1, 6):
+        evaluated = Product(value + S.One/2**k, (k, 0, value - 1)).doit()
+        direct = S.One
+        for k_val in range(value):
+            direct *= value + S.One/2**k_val
+        assert evaluated == direct
+
+
+def test_product_additive_non_geometric_stays_unevaluated():
+    expr = Product(k**(S(2)/3) + 1, (k, 0, n - 1)).doit()
+    assert isinstance(expr, Product)
+
+
+def test_product_additive_negative_power_rule():
+    expr = Product(a + b*q**(-k), (k, 0, n - 1)).doit()
+    expected = a**n * q_pochhammer(-b/a, q**(-1), n)
+    assert simplify(expr/expected) == 1
 
 
 def test_special_products():

--- a/sympy/functions/special/__init__.py
+++ b/sympy/functions/special/__init__.py
@@ -9,3 +9,4 @@ from . import mathieu_functions
 from . import singularity_functions
 
 from . import polynomials
+from . import q_functions

--- a/sympy/functions/special/q_functions.py
+++ b/sympy/functions/special/q_functions.py
@@ -1,0 +1,28 @@
+from __future__ import print_function, division
+
+from sympy.core.function import Function
+from sympy.core.singleton import S
+
+
+class q_pochhammer(Function):
+    r"""The q-Pochhammer symbol ``(a; q)_n``.
+
+    This is defined as :math:`\prod_{k=0}^{n-1} (1 - a q^k)` for
+    non-negative integer ``n`` with ``(a; q)_0 = 1``. The symbolic form is
+    left unevaluated for general ``n`` while preserving the normalization at
+    ``n = 0``.
+    """
+
+    nargs = 3
+
+    @classmethod
+    def eval(cls, a, q, n):
+        if n.is_zero:
+            return S.One
+
+    def _eval_rewrite_as_Product(self, a, q, n, **kwargs):
+        from sympy.concrete.products import Product
+        from sympy.core.symbol import Dummy
+
+        k = Dummy('k')
+        return Product(1 - a*q**k, (k, 0, n - 1))


### PR DESCRIPTION
## Related Issue
- Fixes #29

## Observed Failure
- No exception is raised; the product simplifies to the wrong value.
- Reproduction snippet:
  ```python
  from sympy import Product, symbols
  n = 2
  k = symbols('k')
  print(Product(n + 1/2**k, (k, 0, n - 1)).doit())  # returns 9/2, expected 15/2
  ```
- Incorrect simplification occurs inside `sympy/concrete/products.py::Product._eval_product` when distributing over `Add` terms.

## Fix Summary
- Guard additive products from distributing across non-geometric sums and detect terms of the form `a + b*q**k`.
- Map recognized geometric sums to `a**count * q_pochhammer(-b/a, q, count)` with support for negative exponents.
- Add a minimal `q_pochhammer` special function and regression tests covering geometric and non-geometric additive products.

## Testing
- `PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH python3 -m pytest sympy/concrete/tests/test_products.py`