### PR TITLE
fix: swev-id: sympy__sympy-13852 polylog Li2(1/2) evaluation

### DIFF
--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -1,6 +1,7 @@
 from sympy import (Symbol, zeta, nan, Rational, Float, pi, dirichlet_eta, log,
                    zoo, expand_func, polylog, lerchphi, S, exp, sqrt, I,
-                   exp_polar, polar_lift, O, stieltjes)
+                   exp_polar, polar_lift, O, stieltjes, simplify, nsimplify,
+                   N)
 from sympy.utilities.randtest import (test_derivative_numerically as td,
                       random_complex_number as randcplx, verify_numerically as tn)
 
@@ -128,10 +129,22 @@ def test_polylog_expansion():
     assert polylog(s, 1) == zeta(s)
     assert polylog(s, -1) == -dirichlet_eta(s)
 
-    assert myexpand(polylog(1, z), -log(1 + exp_polar(-I*pi)*z))
+    assert myexpand(polylog(1, z), -log(1 - z))
+    assert not expand_func(polylog(1, z)).has(exp_polar)
+    assert simplify(expand_func(polylog(1, z).diff(z))
+                    - (-log(1 - z)).diff(z)) == 0
+    assert tn(polylog(1, z), -log(1 - z), z)
     assert myexpand(polylog(0, z), z/(1 - z))
     assert myexpand(polylog(-1, z), z**2/(1 - z)**2 + z/(1 - z))
     assert myexpand(polylog(-5, z), None)
+
+
+def test_polylog_dilog_half():
+    target = -log(2)**2/2 + pi**2/12
+    expr = polylog(2, S(1)/2)
+    assert expr == target
+    assert expr.expand(func=True) == target
+    assert nsimplify(N(expr), [pi**2, log(2)**2]) == target
 
 
 def test_lerchphi_expansion():

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -253,7 +253,7 @@ class polylog(Function):
     >>> from sympy import expand_func
     >>> from sympy.abc import z
     >>> expand_func(polylog(1, z))
-    -log(z*exp_polar(-I*pi) + 1)
+    -log(1 - z)
     >>> expand_func(polylog(0, z))
     z/(-z + 1)
 
@@ -271,6 +271,8 @@ class polylog(Function):
 
     @classmethod
     def eval(cls, s, z):
+        if s == 2 and z == S.Half:
+            return pi**2/12 - log(2)**2/2
         if z == 1:
             return zeta(s)
         elif z == -1:
@@ -288,10 +290,10 @@ class polylog(Function):
         return z*lerchphi(z, s, 1)
 
     def _eval_expand_func(self, **hints):
-        from sympy import log, expand_mul, Dummy, exp_polar, I
+        from sympy import log, expand_mul, Dummy
         s, z = self.args
         if s == 1:
-            return -log(1 + exp_polar(-I*pi)*z)
+            return -log(1 - z)
         if s.is_Integer and s <= 0:
             u = Dummy('u')
             start = u/(1 - u)

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -1946,12 +1946,10 @@ def test_R17():
                - 2.8469909700078206) < 1e-15
 
 
-@XFAIL
 def test_R18():
     k = symbols('k', integer=True, positive=True)
     Sm = Sum(1/(2**k*k**2), (k, 1, oo))
-    # returns polylog(2, 1/2),  particular value for 1/2 is not known.
-    # https://github.com/sympy/sympy/issues/7132
+    # polylog(2, 1/2) now evaluates to a known closed form.
     T = Sm.doit()
     assert T.simplify() == -log(2)**2/2 + pi**2/12
 


### PR DESCRIPTION
## Summary
- add Li₂(1/2) closed form to polylog.eval and refresh doc example
- expand polylog(1, z) to -log(1 - z) and extend regression tests
- unxfail Wester R18 now that Li₂(1/2) simplifies correctly

## Testing
- PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:\$PATH python3 -m pytest sympy/functions/special/tests/test_zeta_functions.py
- PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:\$PATH python3 -m pytest sympy/utilities/tests/test_wester.py::test_R18
- PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:\$PATH bin/test code_quality

## Observed failures
- None