### PR TITLE
fix: align Poly right rmul (swev-id: sympy__sympy-13757)

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -106,6 +106,7 @@ class Poly(Expr):
 
     is_commutative = True
     is_Poly = True
+    _op_priority = 10.009
 
     def __new__(cls, rep, *gens, **args):
         """Create a new polynomial instance out of something useful. """
@@ -4049,11 +4050,14 @@ class Poly(Expr):
 
     @_sympifyit('g', NotImplemented)
     def __rmul__(f, g):
+        if getattr(g, 'is_commutative', True) is False:
+            return Mul(g, f)
+
         if not g.is_Poly:
             try:
                 g = f.__class__(g, *f.gens)
             except PolynomialError:
-                return g*f.as_expr()
+                return Mul(g, f)
 
         return g.mul(f)
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -678,6 +678,24 @@ def test_Poly_mul():
     assert 2 * Poly(x, x) == Poly(2*x, x)
 
 
+def test_Poly_rmul_evaluation():
+    a = Symbol('a', commutative=False)
+
+    assert x*Poly(x, x) == Poly(x**2, x)
+    assert S(2)*Poly(x, x) == Poly(2*x, x)
+    assert S(-2)*Poly(x, x) == Poly(-2*x, x)
+
+    assert (S(1)/2) * Poly(x, x, domain=ZZ) == Poly(S(1)/2*x, x, domain='QQ')
+    assert (S(1)/2) * Poly(x, x, domain=QQ) == Poly(S(1)/2*x, x, domain='QQ')
+
+    assert y*Poly(x, x) == Poly(y*x, x, domain='ZZ[y]')
+    assert x*Poly(x + y, x, y) == Poly(x*(x + y), x, y, domain='ZZ')
+
+    assert a*Poly(x, x) == Mul(a, Poly(x, x))
+
+    assert Poly(x, x)*x == Poly(x**2, x)
+    assert Poly(x, x)*S(-2) == Poly(-2*x, x)
+
 def test_Poly_sqr():
     assert Poly(x*y, x, y).sqr() == Poly(x**2*y**2, x, y)
 


### PR DESCRIPTION
Closes #38

## Summary
- raise `Poly`'s `_op_priority` so right-multiplication prefers `Poly.__rmul__`
- return an unevaluated `Mul` when the left operand is non-commutative or cannot be coerced to a matching `Poly`
- add regression coverage for scalar, symbolic, domain-widening, and non-commutative right-multiplication cases

## Reproduction Steps
1. Checkout `sympy__sympy-13757`
2. Apply the regression tests from this change
3. Run `PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH bin/test sympy/polys/tests/test_polytools.py`

## Observed Failure and Stack Trace (pre-fix)
```text
$(cat /workspace/sympy/pre_fix_failure.log 2>/dev/null || cat <<'TRACE'
============================= test process starts ==============================
executable:         /root/.nix-profile/bin/python  (3.11.14-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
numpy:              None
random seed:        69639414
hash randomization: on (PYTHONHASHSEED=385050128)

sympy/polys/tests/test_polytools.py[142] .............................F.........
............................................................................f...
...............ff......                                                   [FAIL]

________________________________________________________________________________
________ sympy/polys/tests/test_polytools.py:test_Poly_rmul_evaluation _________
  File "/workspace/sympy/sympy/polys/tests/test_polytools.py", line 684, in test_Poly_rmul_evaluation
    assert x*Poly(x, x) == Poly(x**2, x)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError

== tests finished: 138 passed, 1 failed, 3 expected to fail, in 0.97 seconds ===
DO *NOT* COMMIT!
TRACE)
```

## Testing
- `PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH bin/test sympy/polys/tests/test_polytools.py`
- `PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:$PATH bin/test code_quality`