### PR TITLE
swev-id: sympy__sympy-13798 allow custom mul_symbol strings

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -156,11 +156,21 @@ class LatexPrinter(Printer):
             "times": r" \times "
         }
 
-        self._settings['mul_symbol_latex'] = \
-            mul_symbol_table[self._settings['mul_symbol']]
+        mul_symbol = self._settings['mul_symbol']
 
-        self._settings['mul_symbol_latex_numbers'] = \
-            mul_symbol_table[self._settings['mul_symbol'] or 'dot']
+        if mul_symbol in mul_symbol_table:
+            self._settings['mul_symbol_latex'] = mul_symbol_table[mul_symbol]
+            self._settings['mul_symbol_latex_numbers'] = (
+                mul_symbol_table[mul_symbol or 'dot']
+            )
+        elif isinstance(mul_symbol, str):
+            custom = f" {mul_symbol} "
+            self._settings['mul_symbol_latex'] = custom
+            self._settings['mul_symbol_latex_numbers'] = custom
+        else:
+            raise ValueError(
+                "mul_symbol must be one of None, 'ldot', 'dot', 'times', or a str LaTeX fragment"
+            )
 
         self._delim_dict = {'(': ')', '[': ']'}
 
@@ -2155,10 +2165,14 @@ def latex(expr, **settings):
     \frac{1}{2 \pi} \int r\, dr
 
     mul_symbol: The symbol to use for multiplication. Can be one of None,
-    "ldot", "dot", or "times".
+    "ldot", "dot", "times", or any custom string containing LaTeX
+    markup.
 
     >>> print(latex((2*tau)**sin(Rational(7,2)), mul_symbol="times"))
     \left(2 \times \tau\right)^{\sin{\left (\frac{7}{2} \right )}}
+
+    >>> print(latex(x*y, mul_symbol="\\ast"))
+    x \ast y
 
     inv_trig_style: How inverse trig functions should be displayed. Can be one
     of "abbreviated", "full", or "power". Defaults to "abbreviated".

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -136,6 +136,25 @@ def test_latex_basic():
     assert latex(exp(-p)*log(p)) == r"e^{- p} \log{\left (p \right )}"
 
 
+def test_latex_mul_symbol_variants():
+    assert latex(4*4**x, mul_symbol='times') == r"4 \times 4^{x}"
+    assert latex(4*4**x, mul_symbol='dot') == r"4 \cdot 4^{x}"
+    assert latex(4*4**x, mul_symbol='ldot') == r"4 \,.\, 4^{x}"
+
+    assert latex(1.5e20*x, mul_symbol='dot') == r"1.5 \cdot 10^{20} \cdot x"
+    assert latex(1.5e20*x, mul_symbol='times') == r"1.5 \times 10^{20} \times x"
+
+    assert latex(3*x**2*y, mul_symbol='\\,') == r"3 \, x^{2} \, y"
+    assert latex(4*4**x, mul_symbol='\\,') == r"4 \, 4^{x}"
+    assert latex(1.5e20*x, mul_symbol='\\,') == r"1.5 \, 10^{20} \, x"
+    assert latex(x*y, mul_symbol='\\ast') == r"x \ast y"
+
+    assert latex(1.5e20*x) == r"1.5 \cdot 10^{20} x"
+    assert latex(2*x*y) == "2 x y"
+
+    raises(ValueError, lambda: latex(x*y, mul_symbol=123))
+
+
 def test_latex_builtins():
     assert latex(True) == r"\mathrm{True}"
     assert latex(False) == r"\mathrm{False}"


### PR DESCRIPTION
## Summary
- allow LatexPrinter to accept custom string `mul_symbol` values while preserving the legacy mapping
- document the new option and error handling
- add regression tests covering legacy separators, custom fragments, and invalid inputs

## Testing
- PYTHONPATH=/workspace/pythoncompat:/workspace/sympy PATH=/root/.local/bin:$PATH bin/test sympy/printing/tests/test_latex.py
- PYTHONPATH=/workspace/pythoncompat:/workspace/sympy PATH=/root/.local/bin:$PATH bin/test code_quality

## Original Failure
Reproduced on the base branch with:
```bash
python - <<'PY'
from sympy import symbols, latex
x, y = symbols('x y')
print(latex(3*x**2*y, mul_symbol='\\,'))
PY
```

Stack trace:
```text
/workspace/sympy/sympy/external/importtools.py:5: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.version import StrictVersion
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File "/workspace/sympy/sympy/printing/latex.py", line 2203, in latex
    return LatexPrinter(settings).doprint(expr)
  File "/workspace/sympy/sympy/printing/latex.py", line 160, in __init__
    mul_symbol_table[self._settings['mul_symbol']]
KeyError: '\\,'
```

Fixes #37