### PR TITLE
fix: stabilize bareiss determinant (swev-id: sympy__sympy-13877)

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -168,16 +168,37 @@ class MatrixDeterminant(MatrixCommon):
         elimination method. This approach is best suited for dense
         symbolic matrices and will result in a determinant with
         minimal number of fractions. It means that less term
-        rewriting is needed on resulting formulae.
+        rewriting is needed on resulting formulae.  If symbolic
+        cancellation fails or produces ``NaN``, the algorithm falls
+        back to the LU-based determinant evaluation.
 
         TODO: Implement algorithm for sparse matrices (SFF),
         http://www.eecis.udel.edu/~saunders/papers/sffge/it5.ps.
         """
 
+        def _has_nan_expr(expr):
+            if expr is S.NaN:
+                return True
+            try:
+                return expr.has(S.NaN)
+            except AttributeError:
+                return False
+
+        def _mat_contains_nan(mat):
+            return any(
+                _has_nan_expr(mat[i, j])
+                for i in range(mat.rows)
+                for j in range(mat.cols)
+            )
+
         # XXX included as a workaround for issue #12362.  Should use `_find_reasonable_pivot` instead
         def _find_pivot(l):
-            for pos,val in enumerate(l):
-                if val:
+            for pos, val in enumerate(l):
+                val = val.expand()
+                if _has_nan_expr(val):
+                    continue
+                is_zero = val.is_zero
+                if is_zero is False:
                     return (pos, val, None, None)
             return (None, None, None, None)
 
@@ -208,12 +229,22 @@ class MatrixDeterminant(MatrixCommon):
             def entry(i, j):
                 ret = (pivot_val*tmp_mat[i, j + 1] - mat[pivot_pos, j + 1]*tmp_mat[i, 0]) / cumm
                 if not ret.is_Atom:
-                    cancel(ret)
+                    ret = cancel(ret)
                 return ret
 
             return sign*bareiss(self._new(mat.rows - 1, mat.cols - 1, entry), pivot_val)
 
-        return cancel(bareiss(self))
+        contains_nan = _mat_contains_nan(self)
+        res = bareiss(self)
+        try:
+            res = cancel(res)
+        except (TypeError, ZeroDivisionError):
+            if not contains_nan:
+                return self._eval_det_lu()
+            raise
+        if _has_nan_expr(res) and not contains_nan:
+            return self._eval_det_lu()
+        return res
 
     def _eval_det_berkowitz(self):
         """ Use the Berkowitz algorithm to compute the determinant."""

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -470,6 +470,33 @@ def test_det_LU_decomposition():
     assert M.det(method="lu") == z**2 - x*y
 
 
+def _expr_contains_nan(expr):
+    return expr is S.NaN or getattr(expr, "has", lambda *_: False)(S.NaN)
+
+
+def test_det_symbolic_vs_lu_no_nan():
+    for n in range(1, 7):
+        M = Matrix([[i + a*j for i in range(n)] for j in range(n)])
+        det_default = M.det()
+        det_lu = M.det(method="lu")
+        assert det_default == det_lu
+        assert not _expr_contains_nan(det_default)
+        if n in (5, 6):
+            det_bareiss = M.det(method="bareiss")
+            assert det_bareiss == det_lu
+            assert not _expr_contains_nan(det_bareiss)
+
+
+def test_det_bareiss_pathological_zero():
+    M = Matrix([[x, x], [x, x]])
+    det_default = M.det()
+    det_lu = M.det(method="lu")
+    det_bareiss = M.det(method="bareiss")
+    assert det_default == det_lu == det_bareiss == S.Zero
+    assert not _expr_contains_nan(det_default)
+    assert not _expr_contains_nan(det_bareiss)
+
+
 def test_slicing():
     m0 = eye(4)
     assert m0[:3, :3] == eye(3)


### PR DESCRIPTION
## Summary
- harden Bareiss pivot selection to ignore NaN entries and rely on tri-state zero checks
- normalize Bareiss intermediate cancellation and fall back to LU when cancellation fails or yields NaN
- add determinant regressions covering symbolic grids and degenerate duplicates

## Testing
- PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:/root/.nix-profile/bin:$PATH bin/test sympy/matrices/tests/test_matrices.py
- PYTHONPATH=/workspace/pythoncompat PATH=/root/.local/bin:/root/.nix-profile/bin:$PATH bin/test code_quality

Fixes #39

## Reproduction
```python
from sympy import *
from sympy.abc import a
f = lambda n: det(Matrix([[i + a*j for i in range(n)] for j in range(n)]))

f(1)  # 0
f(2)  # -a
f(3)  # 2*a*(a + 2) + 2*a*(2*a + 1) - 3*a*(2*a + 2)
f(4)  # 0
f(5)  # nan
f(6)  # TypeError: Invalid NaN comparison
```

### Observed failure and stack trace (sympy__sympy-13877)
```
Traceback (most recent call last):
  ...
  File "sympy/matrices/matrices.py", line 213, in _eval_det_bareiss
    return cancel(bareiss(self))
  File "sympy/polys/polytools.py", line 6423, in cancel
    f = factor_terms(f, radical=True)
  File "sympy/core/exprtools.py", line 1171, in do
    if all(a.as_coeff_Mul()[0] < 0 for a in list_args):
  File "sympy/core/expr.py", line 323, in __lt__
    raise TypeError("Invalid NaN comparison")
TypeError: Invalid NaN comparison
```