### PR TITLE
swev-id: sympy__sympy-13974 distribute pow simplification

### DIFF
--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -268,6 +268,13 @@ class TensorProduct(Expr):
                          for idx, value in enumerate(exp.args)])
 
 
+def tensor_product_simp_Pow(e, **hints):
+    base_simpl = tensor_product_simp(e.base, **hints)
+    if isinstance(base_simpl, TensorProduct):
+        return TensorProduct(*[arg**e.exp for arg in base_simpl.args])
+    return base_simpl ** e.exp
+
+
 def tensor_product_simp_Mul(e):
     """Simplify a Mul with TensorProducts.
 
@@ -382,7 +389,7 @@ def tensor_product_simp(e, **hints):
     if isinstance(e, Add):
         return Add(*[tensor_product_simp(arg) for arg in e.args])
     elif isinstance(e, Pow):
-        return tensor_product_simp(e.base) ** e.exp
+        return tensor_product_simp_Pow(e, **hints)
     elif isinstance(e, Mul):
         return tensor_product_simp_Mul(e)
     elif isinstance(e, Commutator):

--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -383,7 +383,7 @@ def tensor_product_simp(e, **hints):
     commutators and anticommutators as well:
 
     >>> tensor_product_simp(e**2)
-    (A*C)x(B*D)**2
+    (A*C)**2x(B*D)**2
 
     """
     if isinstance(e, Add):

--- a/sympy/physics/quantum/tests/test_tensorproduct.py
+++ b/sympy/physics/quantum/tests/test_tensorproduct.py
@@ -1,4 +1,4 @@
-from sympy import I, symbols, Matrix
+from sympy import I, Matrix, Symbol, symbols
 
 from sympy.physics.quantum.commutator import Commutator as Comm
 from sympy.physics.quantum.tensorproduct import TensorProduct
@@ -9,8 +9,9 @@ from sympy.physics.quantum.qubit import Qubit, QubitBra
 from sympy.physics.quantum.operator import OuterProduct
 from sympy.physics.quantum.density import Density
 from sympy.core.trace import Tr
+from sympy.physics.paulialgebra import Pauli
 
-A, B, C = symbols('A,B,C', commutative=False)
+A, B, C, D = symbols('A,B,C,D', commutative=False)
 x = symbols('x')
 
 mat1 = Matrix([[1, 2*I], [1 + I, 3]])
@@ -47,6 +48,17 @@ def test_tensor_product_commutator():
 
 def test_tensor_product_simp():
     assert tensor_product_simp(TP(A, B)*TP(B, C)) == TP(A*B, B*C)
+
+
+def test_tensor_product_pow_distribution():
+    a = Symbol('a', commutative=False)
+    assert tensor_product_simp(TP(1, 1)**2) == TensorProduct(1, 1)
+    assert tensor_product_simp(TP(1, Pauli(3))**2) == TensorProduct(1, 1)
+    assert tensor_product_simp(TP(1, a)**2).subs(a, 1) == TensorProduct(1, 1)
+
+    e = TP(A, B) * TP(C, D)
+    expected = TP((A*C)**2, (B*D)**2)
+    assert tensor_product_simp(e**2) == expected
 
 
 def test_issue_5923():


### PR DESCRIPTION
## Summary
- distribute tensor_product_simp over Pow via helper
- ensure tensor factors are exponentiated individually
- cover regression cases for scalar, operator, and symbolic factors

## Testing
- PYTHONPATH=/workspace/pythoncompat:/workspace/sympy PATH=/root/.local/bin:$PATH bin/test sympy/physics/quantum/tests/test_tensorproduct.py
- PYTHONPATH=/workspace/pythoncompat:/workspace/sympy PATH=/root/.local/bin:$PATH bin/test code_quality

Fixes #44