### PR TITLE
swev-id: sympy__sympy-15345 - Sort Mathematica Min/Max args

### DIFF
--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -6,6 +6,7 @@ from __future__ import print_function, division
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.str import StrPrinter
 from sympy.printing.precedence import precedence
+from sympy.utilities.iterables import default_sort_key
 
 # Used in MCodePrinter._print_Function(self)
 known_functions = {
@@ -100,6 +101,14 @@ class MCodePrinter(CodePrinter):
                 if cond(*expr.args):
                     return "%s[%s]" % (mfunc, self.stringify(expr.args, ", "))
         return expr.func.__name__ + "[%s]" % self.stringify(expr.args, ", ")
+
+    def _print_Max(self, expr):
+        args = sorted(expr.args, key=default_sort_key)
+        return "Max[%s]" % self.stringify(args, ", ")
+
+    def _print_Min(self, expr):
+        args = sorted(expr.args, key=default_sort_key)
+        return "Min[%s]" % self.stringify(args, ", ")
 
     def _print_Integral(self, expr):
         if len(expr.variables) == 1 and not expr.limits[0][1:]:

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -2,7 +2,7 @@ from sympy.core import (S, pi, oo, symbols, Function,
                         Rational, Integer, Tuple, Derivative)
 from sympy.integrals import Integral
 from sympy.concrete import Sum
-from sympy.functions import exp, sin, cos, conjugate
+from sympy.functions import exp, sin, cos, conjugate, Max, Min
 
 from sympy import mathematica_code as mcode
 
@@ -28,6 +28,13 @@ def test_Function():
     assert mcode(f(x, y, z)) == "f[x, y, z]"
     assert mcode(sin(x) ** cos(x)) == "Sin[x]^Cos[x]"
     assert mcode(conjugate(x)) == "Conjugate[x]"
+
+
+def test_MinMax():
+    assert mcode(Max(x, 2)) == "Max[2, x]"
+    assert mcode(Max(2, x)) == "Max[2, x]"
+    assert mcode(Min(x, 2)) == "Min[2, x]"
+    assert mcode(Min(2, x)) == "Min[2, x]"
 
 
 def test_Pow():


### PR DESCRIPTION
## Summary
- import default_sort_key into the Mathematica printer
- sort Max/Min arguments before printing to Mathematica syntax
- add Max/Min ordering tests for mcode printer

## Testing
- PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test sympy/printing/tests/test_mathematica.py
- PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test code_quality

Closes #54