### PR TITLE
swev-id: sympy__sympy-14711 – handle zero addition in Vector.__add__

### DIFF
--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -1,5 +1,6 @@
-from sympy import symbols, pi, sin, cos, ImmutableMatrix as Matrix
-from sympy.physics.vector import ReferenceFrame, Vector, dynamicsymbols, dot
+from sympy import S, symbols, pi, sin, cos, ImmutableMatrix as Matrix
+from sympy.physics.vector import (ReferenceFrame, Vector, dynamicsymbols,
+    dot, outer)
 from sympy.abc import x, y, z
 from sympy.utilities.pytest import raises
 
@@ -57,6 +58,22 @@ def test_Vector():
     #Test the free_symbols property
     v6 = x*A.x + y*A.y + z*A.z
     assert v6.free_symbols(A) == {x,y,z}
+
+
+def test_vector_add_zero_no_op():
+    N = ReferenceFrame('N')
+    v = N.x
+
+    assert (v + 0) is v
+    assert (0 + v) is v
+    assert (v + S.Zero) is v
+    assert (S.Zero + v) is v
+
+    assert sum([v, 0 * v]) == v
+    assert sum([v]) == v
+    assert sum([], start=v) is v
+
+    raises(TypeError, lambda: v + outer(N.x, N.x) * 0)
 
 
 def test_Vector_diffs():

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -57,6 +57,8 @@ class Vector(object):
 
     def __add__(self, other):
         """The add operator for Vector. """
+        if (type(other) is int and other == 0) or other is S.Zero:
+            return self
         other = _check_vector(other)
         return Vector(self.args + other.args)
 


### PR DESCRIPTION
## Summary
- return the original vector when `__add__` receives an integer zero or `S.Zero`
- extend vector tests with zero-sum regressions and ensure dyadic zero still errors

Fixes #52

## Reproduction
```python
from sympy.physics.vector import ReferenceFrame, Vector
from sympy import symbols
N = ReferenceFrame('N')
sum([N.x, (0 * N.x)])
```

## Testing
- `PYTHONPATH=/workspace/pythoncompat:/workspace/sympy PATH=/root/.local/bin:$PATH bin/test sympy/physics/vector/tests` (47 passed)