### PR TITLE
swev-id: sympy__sympy-15017 fix: len(Array(3)) returns 1 for rank-0 arrays

### DIFF
--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -175,7 +175,7 @@ class NDimArray(object):
         9
 
         """
-        return self._loop_size
+        if self._rank == 0:\n            return 1\n        return self._loop_size
 
     @property
     def shape(self):

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -175,7 +175,9 @@ class NDimArray(object):
         9
 
         """
-        if self._rank == 0:\n            return 1\n        return self._loop_size
+        if self._rank == 0:
+            return 1
+        return self._loop_size
 
     @property
     def shape(self):

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -73,7 +73,7 @@ def test_ndim_array_initiation():
 
     from sympy.abc import x
     rank_zero_array = ImmutableDenseNDimArray(x)
-    assert len(rank_zero_array) == 0
+    assert len(rank_zero_array) == 1
     assert rank_zero_array.shape == ()
     assert rank_zero_array.rank() == 0
     assert rank_zero_array[()] == x
@@ -384,3 +384,21 @@ def test_issue_12665():
     arr = ImmutableDenseNDimArray([1, 2, 3])
     # This should NOT raise an exception:
     hash(arr)
+
+def test_len_rank_cases():
+    from sympy import Array
+
+    rank_zero = Array(3)
+    assert rank_zero.rank() == 0
+    assert rank_zero.shape == ()
+    assert len(rank_zero) == 1
+
+    rank_one = Array([1, 2, 3])
+    assert rank_one.rank() == 1
+    assert rank_one.shape == (3,)
+    assert len(rank_one) == 3
+
+    rank_two = Array([[1, 2], [3, 4]])
+    assert rank_two.rank() == 2
+    assert rank_two.shape == (2, 2)
+    assert len(rank_two) == 4


### PR DESCRIPTION
This PR addresses issue #55: `len` of rank-0 arrays returns 0.

Summary:
- Special-case rank-0 in `NDimArray.__len__` to return 1 (total elements), preserving existing semantics for rank>=1.
- Update tests to expect `len` of rank-0 arrays to be 1 and add coverage across ranks.

Rationale:
- SymPy arrays use `len` to mean total number of elements. Rank-0 arrays store a single element; `len` should reflect that.
- Aligns with iteration cardinality and numpy’s `size` semantics for scalars (`np.asarray(1).size == 1`).

Notes:
- Indexing semantics are unchanged: `a[()]` is valid for rank-0; `a[0]` raises `ValueError`.

Issue: https://github.com/agyn-sandbox/sympy/issues/55