### PR TITLE
swev-id: sympy__sympy-14976 ensure mpmath lambdify rational precision

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -331,6 +331,14 @@ class MpmathPrinter(PythonCodePrinter):
         args = str(tuple(map(int, e._mpf_)))
         return '{func}({args})'.format(func=self._module_format('mpmath.mpf'), args=args)
 
+    def _print_Rational(self, expr):
+        mpf = self._module_format('mpmath.mpf')
+        p = expr.p
+        q = expr.q
+        if q == 1:
+            return f'{mpf}({p})'
+        return f'{mpf}({p})/{mpf}({q})'
+
 
     def _print_uppergamma(self, e):
         return "{0}({1}, {2}, {3})".format(

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 
 from sympy.codegen import Assignment
 from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo
-from sympy.core.numbers import pi
+from sympy.core.numbers import pi, Rational
 from sympy.codegen.ast import none
 from sympy.external import import_module
 from sympy.logic import And, Or
@@ -40,6 +40,11 @@ def test_PythonCodePrinter():
 def test_MpmathPrinter():
     p = MpmathPrinter()
     assert p.doprint(sign(x)) == 'mpmath.sign(x)'
+
+
+def test_MpmathPrinter_rational():
+    p = MpmathPrinter()
+    assert p.doprint(Rational(232, 3)) == 'mpmath.mpf(232)/mpmath.mpf(3)'
 
 
 def test_NumPyPrinter():

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -1,5 +1,5 @@
 from sympy import (Eq, Matrix, pi, sin, sqrt, Symbol, Integral, Piecewise,
-    symbols, Float, I)
+    symbols, Float, I, Rational)
 from mpmath import mnorm, mpf
 from sympy.solvers import nsolve
 from sympy.utilities.lambdify import lambdify
@@ -99,6 +99,14 @@ def test_nsolve_precision():
     assert abs(sqrt(pi).evalf(128) - sols[0]) < 1e-128
     assert abs(sqrt(sqrt(pi)).evalf(128) - sols[1]) < 1e-128
     assert all(isinstance(i, Float) for i in sols)
+
+
+def test_nsolve_rational_precision():
+    x = Symbol('x')
+    target = Rational(1, 3)
+    sol = nsolve(x - target, 0.3, prec=80)
+    error = abs(sol - target).evalf(85)
+    assert error < Float('1e-80', 270)
 
 def test_nsolve_complex():
     x, y = symbols('x y')

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -157,6 +157,14 @@ def test_mpmath_precision():
     mpmath.mp.dps = 100
     assert str(lambdify((), pi.evalf(100), 'mpmath')()) == str(pi.evalf(100))
 
+
+def test_mpmath_rational_source_precision():
+    f = lambdify(x, Rational(232, 3), modules='mpmath')
+    source = inspect.getsource(f)
+    assert 'mpf(' in source
+    assert '232/3' not in source
+    assert f.__globals__['mpf'] is mpmath.mpf
+
 #================== Test Translations ==============================
 # We can only check if all translated functions are valid. It has to be checked
 # by hand if they are complete.


### PR DESCRIPTION
Fixes #53.

## Reproduction Steps
1. Checkout `sympy__sympy-14976`.
2. Apply the added regression tests (or cherry-pick 647b688).
3. Run the targeted suites:
   - `PATH=/root/.local/bin:$PATH bin/test sympy/utilities/tests/test_lambdify.py`
   - `PATH=/root/.local/bin:$PATH bin/test sympy/solvers/tests/test_numeric.py`
   - `PATH=/root/.local/bin:$PATH bin/test sympy/printing/tests/test_pycode.py`

## Observed Failure (pre-fix)
```text
============================= test process starts ==============================
...
________________________________________________________________________________
_ sympy/utilities/tests/test_lambdify.py:test_mpmath_rational_source_precision _
Traceback (most recent call last):
  File "/workspace/sympy/sympy/utilities/tests/test_lambdify.py", line 164, in test_mpmath_rational_source_precision
    assert 'mpf(' in source
           ^^^^^^^^^^^^^^^^
AssertionError
```

```text
============================= test process starts ==============================
...
________________________________________________________________________________
______ sympy/solvers/tests/test_numeric.py:test_nsolve_rational_precision ______
Traceback (most recent call last):
  File "/workspace/sympy/sympy/solvers/tests/test_numeric.py", line 109, in test_nsolve_rational_precision
    assert error < Float('1e-80', 270)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

```text
============================= test process starts ==============================
...
________________________________________________________________________________
_______ sympy/printing/tests/test_pycode.py:test_MpmathPrinter_rational ________
Traceback (most recent call last):
  File "/workspace/sympy/sympy/printing/tests/test_pycode.py", line 47, in test_MpmathPrinter_rational
    assert p.doprint(Rational(232, 3)) == 'mpmath.mpf(232)/mpmath.mpf(3)'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

## Fix
- Teach `MpmathPrinter` how to emit rationals via `mpmath.mpf`, so lambdified constants are created at runtime rather than being embedded as eager Python fractions.
- Extend the mpmath lambdify, numeric solver, and printer suites with regressions that guard precision behaviour.

This keeps rational literals in the mpmath pathway from truncating to machine doubles while reusing the existing module formatting so the mpf constructor is resolved from `mpmath` at call-time, preserving arbitrary precision.

## Verification
- `PATH=/root/.local/bin:$PATH bin/test sympy/utilities/tests/test_lambdify.py`
- `PATH=/root/.local/bin:$PATH bin/test sympy/solvers/tests/test_numeric.py`
- `PATH=/root/.local/bin:$PATH bin/test sympy/printing/tests/test_pycode.py`
- `PATH=/root/.local/bin:$PATH bin/test code_quality`