### PR TITLE
swev-id: sympy__sympy-15349 fix quaternion rotation matrix sign

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -529,7 +529,7 @@ class Quaternion(Expr):
 
         m10 = 2*s*(q.b*q.c + q.d*q.a)
         m11 = 1 - 2*s*(q.b**2 + q.d**2)
-        m12 = 2*s*(q.c*q.d + q.b*q.a)
+        m12 = 2*s*(q.c*q.d - q.b*q.a)
 
         m20 = 2*s*(q.b*q.d - q.c*q.a)
         m21 = 2*s*(q.c*q.d + q.b*q.a)

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -3,6 +3,7 @@ from sympy import symbols, re, im, Add, Mul, I, Abs
 from sympy import cos, sin, sqrt, conjugate, exp, log, acos, E, pi
 from sympy.utilities.pytest import raises
 from sympy import Matrix
+from sympy.matrices import rot_axis1, rot_axis2, rot_axis3
 from sympy import diff, integrate, trigsimp
 from sympy import S, Rational
 
@@ -120,3 +121,45 @@ def test_quaternion_conversions():
                [sin(theta),  cos(theta), 0, -sin(theta) - cos(theta) + 1],
                [0,           0,          1,  0],
                [0,           0,          0,  1]])
+
+
+def test_to_rotation_matrix_axis_signs():
+    def _rx(angle):
+        return Matrix([
+            [1, 0, 0],
+            [0, cos(angle), -sin(angle)],
+            [0, sin(angle), cos(angle)],
+        ])
+
+    def _ry(angle):
+        return Matrix([
+            [cos(angle), 0, sin(angle)],
+            [0, 1, 0],
+            [-sin(angle), 0, cos(angle)],
+        ])
+
+    def _rz(angle):
+        return Matrix([
+            [cos(angle), -sin(angle), 0],
+            [sin(angle), cos(angle), 0],
+            [0, 0, 1],
+        ])
+
+    angles = [0, pi/2, pi]
+    test_data = [
+        ((1, 0, 0), _rx, rot_axis1),
+        ((0, 1, 0), _ry, rot_axis2),
+        ((0, 0, 1), _rz, rot_axis3),
+    ]
+
+    zero = Matrix.zeros(3)
+
+    for axis, expected_matrix, rot_axis in test_data:
+        for angle in angles:
+            quat = Quaternion.from_axis_angle(axis, angle)
+            result = quat.to_rotation_matrix()
+            expected = expected_matrix(angle)
+            diff_expected = trigsimp(result - expected)
+            diff_rot_axis = trigsimp(result - rot_axis(-angle))
+            assert diff_expected == zero
+            assert diff_rot_axis == zero


### PR DESCRIPTION
## Summary
- correct the quaternion rotation matrix m12 sign
- add axis rotation regression tests covering expected Rx/Ry/Rz matrices
- verify compatibility with rot_axis1/2/3 conventions

## Testing
- PATH=/root/.local/bin:$PATH PYTHONPATH=/workspace/sympy pytest sympy/algebras/tests/test_quaternion.py::test_to_rotation_matrix_axis_signs -q

Closes #60