### PR TITLE
swev-id: sympy__sympy-15599 Fix Mod integer-coefficient simplification; add tests

### DIFF
--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from sympy.core.numbers import nan
+from sympy.core.numbers import Integer, nan
 from .function import Function
 
 
@@ -91,6 +91,63 @@ class Mod(Function):
         rv = doit(p, q)
         if rv is not None:
             return rv
+
+        if q.is_Integer and q > 0:
+            # Only normalize integer arguments when the modulus is a positive
+            # Integer. Do not attempt to distribute through division or handle
+            # symbolic moduli here; those cases fall back to the general logic
+            # below.
+            if p.is_Mul:
+                coeff, rest = p.as_coeff_Mul()
+                if coeff and coeff.is_integer and rest.is_integer is True:
+                    coeff_mod = Integer(coeff % q)
+                    if coeff_mod == 0:
+                        return S.Zero
+                    if coeff_mod != coeff:
+                        if coeff_mod == 1:
+                            return cls(rest, q)
+                        return cls(coeff_mod*rest, q)
+            elif p.is_Add:
+                terms = []
+                const_total = S.Zero
+                have_constant = False
+                changed = False
+                for term in p.args:
+                    if term.is_Integer:
+                        const_total += term
+                        have_constant = True
+                        continue
+                    coeff, rest = term.as_coeff_Mul()
+                    if coeff.is_integer and rest.is_integer is True:
+                        coeff_mod = Integer(coeff % q)
+                        if coeff_mod == 0:
+                            changed = True
+                            continue
+                        term_candidate = coeff_mod*rest
+                        if term_candidate != term:
+                            changed = True
+                        if term_candidate.is_Integer:
+                            const_total += term_candidate
+                            have_constant = True
+                        else:
+                            terms.append(term_candidate)
+                        continue
+                    terms.append(term)
+
+                if have_constant:
+                    const_mod = Integer(const_total % q)
+                    if const_mod != const_total:
+                        changed = True
+                    if const_mod:
+                        terms.append(const_mod)
+                    elif const_total != S.Zero:
+                        changed = True
+
+                if changed:
+                    if not terms:
+                        return S.Zero
+                    new_arg = Add(*terms)
+                    return cls(new_arg, q)
 
         # denest
         if isinstance(p, cls):

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1515,6 +1515,22 @@ def test_Mod():
     assert Mod(-5, 3) == 1
     assert Mod(5, -3) == -1
     assert Mod(-5, -3) == -2
+    i = symbols('i', integer=True)
+    e = symbols('e', even=True)
+    m = symbols('m', integer=True, positive=True)
+    assert Mod(3*i, 2) == Mod(i, 2)
+    assert Mod(2*i, 2) == 0
+    assert Mod(-3*i, 2) == Mod(i, 2)
+    assert Mod(9*i, 6) == Mod(3*i, 6)
+    assert Mod(3*x, 2) == Mod(3*x, 2)
+    assert Mod(e/2, 2) == Mod(e/2, 2)
+    assert Mod(6/2, 2) == 1
+    assert Mod((e.subs(e, 6))/2, 2) == Mod(3, 2)
+    assert Mod(2*i + 1, 2) == 1
+    assert Mod(2*i + 3, 2) == 1
+    assert Mod(6*i + 4, 2) == 0
+    assert Mod(3*i, m) == Mod(3*i, m)
+    assert Mod((i + 1)*(i + 2), 2) == Mod((i + 1)*(i + 2), 2)
     assert type(Mod(3.2, 2, evaluate=False)) == Mod
     assert 5 % x == Mod(5, x)
     assert x % 5 == Mod(x, 5)


### PR DESCRIPTION
Issue: #61

## Summary
- canonicalize `Mod` arguments with positive integer moduli by reducing
  integer coefficients in products and dropping additive terms that are
  multiples of the modulus
- skip transformations when the modulus is symbolic or non-positive and when
  the argument is not known to be integer-valued (e.g. division expressions)
- expand arithmetic tests to cover integer-only simplifications and guard
  scenarios that must remain unchanged

## Testing
- `python -m pytest sympy/core/tests/test_arit.py::test_Mod -q`
- `PATH=/root/.nix-profile/bin:$PATH bin/test sympy/core/tests/test_arit.py`
- `PATH=/root/.nix-profile/bin:$PATH bin/test code_quality`

## Failing test before fix

```
        assert Mod(5, 3) == 2
        assert Mod(-5, 3) == 1
        assert Mod(5, -3) == -1
        assert Mod(-5, -3) == -2
        i = symbols('i', integer=True)
>       assert Mod(3*i, 2) == Mod(i, 2)
E       assert Mod(3*i, 2) == Mod(i, 2)
E        +  where Mod(3*i, 2) = Mod((3 * i), 2)
E        +  and   Mod(i, 2) = Mod(i, 2)

sympy/core/tests/test_arit.py:1519: AssertionError
```

### Reproduction steps
1. `git checkout sympy__sympy-15599`
2. add the test `assert Mod(3*i, 2) == Mod(i, 2)` to `sympy/core/tests/test_arit.py`
3. `python -m pytest sympy/core/tests/test_arit.py -q`
4. observe failure

<!-- BEGIN RELEASE NOTES -->
* core
  * Improve canonicalization of Mod for integer-coefficient products and sums:
    e.g., Mod(3*i, 2) -> Mod(i, 2). Avoids changes for division and non-integer
    expressions.
<!-- END RELEASE NOTES -->
