### PR TITLE
Fix Add.is_zero incorrect False for complex sums (swev-id: sympy__sympy-15875)

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -560,8 +560,7 @@ class Add(Expr, AssocOp):
         if b.is_zero:
             if not im_or_z and not im:
                 return True
-            if im and not im_or_z:
-                return False
+            return None
         if b.is_zero is False:
             return False
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1,5 +1,5 @@
 from sympy import (Basic, Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
-        sympify, Add, Mul, Pow, Mod, I, log, S, Max, symbols, oo, zoo, Integer,
+        sympify, simplify, Add, Mul, Pow, Mod, I, log, S, Max, symbols, oo, zoo, Integer,
         sign, im, nan, Dummy, factorial, comp, refine
 )
 from sympy.core.compatibility import long, range
@@ -1985,6 +1985,14 @@ def test_issue_8247_8354():
 def test_Add_is_zero():
     x, y = symbols('x y', zero=True)
     assert (x + y).is_zero
+
+
+def test_add_is_zero_complex_cancellation():
+    e = -2*I + (1 + I)**2
+    assert e.is_zero in (True, None)
+    assert simplify(e).is_zero is True
+    assert (1 + I).is_zero is False
+    assert (-2*I + 2*I).is_zero is True
 
 
 def test_issue_14392():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2798,6 +2798,12 @@ def test_rank():
     p = zeros(3)
     assert p.rank() == 0
 
+
+def test_rank_with_complex_cancellation():
+    e = -2*I + (1 + I)**2
+    assert Matrix([[e]]).rank() == 0
+
+
 def test_issue_11434():
     ax, ay, bx, by, cx, cy, dx, dy, ex, ey, t0, t1 = \
         symbols('a_x a_y b_x b_y c_x c_y d_x d_y e_x e_y t_0 t_1')


### PR DESCRIPTION
## Summary
- return `None` from `Add._eval_is_zero` when the real cancellation leaves undecidable complex contributions instead of incorrectly returning `False`
- add regression coverage for the complex cancellation case in `sympy.core.tests.test_arit` and matrix rank regression in `sympy.matrices.tests.test_matrices`
- document observed incorrect matrix rank of 1 before the fix and confirm `simplify(e)` already resolves the expression to zero

## Issue
- Closes #64

## Reproduction
```python
from sympy import I, simplify

e = -2*I + (1 + I)**2
e.is_zero  # False (before fix)
simplify(e).is_zero  # True
```

## Observed failure (pre-fix)
```
=================================== FAILURES ===================================
__________________________ test_is_zero_complex_issue __________________________

    def test_is_zero_complex_issue():
        e = -2*I + (1 + I)**2
>       assert e.is_zero in (True, None)
E       assert False in (True, None)
E        +  where False = -2*I + (1 + I)**2.is_zero

/tmp/test_is_zero_failure.py:5: AssertionError
```

## Additional notes
- Before the fix `Matrix([[e]]).rank()` evaluated to `1`; after this change it now resolves to `0` as expected.

<!-- BEGIN RELEASE NOTES -->
- core
  - Fix `is_zero` becoming `False` on some expressions with `Add`.
<!-- END RELEASE NOTES -->