### PR TITLE
feat: support Indexed pycode (swev-id: sympy__sympy-16766)

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -357,6 +357,18 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
         PREC = precedence(expr)
         return self._operators['not'] + self.parenthesize(expr.args[0], PREC)
 
+    def _print_Indexed(self, expr):
+        base = expr.base
+        if hasattr(base, 'label'):
+            base_str = self._print(base.label)
+        else:
+            base_str = self._print(base)
+        indices_str = ', '.join(self._print(index) for index in expr.indices)
+        return '{}[{}]'.format(base_str, indices_str)
+
+    def _print_Idx(self, expr):
+        return self._print(expr.label)
+
 
 for k in PythonCodePrinter._kf:
     setattr(PythonCodePrinter, '_print_%s' % k, _print_known_func)

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -12,6 +12,7 @@ from sympy.printing.pycode import (
     MpmathPrinter, NumPyPrinter, PythonCodePrinter, pycode, SciPyPrinter
 )
 from sympy.utilities.pytest import raises
+from sympy.tensor.indexed import Idx, IndexedBase
 
 x, y, z = symbols('x y z')
 
@@ -66,6 +67,22 @@ def test_pycode_reserved_words():
     raises(ValueError, lambda: pycode(s1 + s2, error_on_reserved=True))
     py_str = pycode(s1 + s2)
     assert py_str in ('else_ + if_', 'if_ + else_')
+
+
+def test_pycode_Indexed_simple():
+    base = IndexedBase('p')
+    result = pycode(base[0])
+    assert result == 'p[0]'
+    assert 'Not supported' not in result
+
+
+def test_pycode_Indexed_multi_and_symbolic_indices():
+    base = IndexedBase('A')
+    i, j = symbols('i j')
+    k = Idx('k')
+
+    assert pycode(base[i, j]) == 'A[i, j]'
+    assert pycode(base[i + j, k]) == 'A[i + j, k]'
 
 
 class CustomPrintedObject(Expr):


### PR DESCRIPTION
## Summary
- add PythonCodePrinter handling for Indexed and Idx nodes so standard indexing is emitted
- cover simple, multi-dimensional, and symbolic index cases via new pycode tests

## Testing
- PATH=/root/.local/bin:$PATH PYTHONPATH=/workspace/sympy bin/test sympy/printing/tests/test_pycode.py
- PATH=/root/.local/bin:$PATH PYTHONPATH=/workspace/sympy bin/test code_quality

Resolves #71.