### PR TITLE
fix: swev-id: sympy__sympy-16450 preserve posify assumptions

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -251,8 +251,27 @@ def posify(eq):
             eq[i] = e.subs(reps)
         return f(eq), {r: s for s, r in reps.items()}
 
-    reps = {s: Dummy(s.name, positive=True)
-                 for s in eq.free_symbols if s.is_positive is None}
+    reps = {}
+    for s in eq.free_symbols:
+        if s.is_positive is not None:
+            continue
+
+        assumptions = dict(s.assumptions0)
+        assumptions.pop('positive', None)
+
+        contradictory_true = ('negative', 'nonpositive', 'zero', 'imaginary')
+        for key in contradictory_true:
+            if assumptions.get(key) is True:
+                assumptions.pop(key, None)
+
+        contradictory_false = ('real', 'nonzero', 'nonnegative')
+        for key in contradictory_false:
+            if assumptions.get(key) is False:
+                assumptions.pop(key, None)
+
+        assumptions['positive'] = True
+        reps[s] = Dummy(s.name, **assumptions)
+
     eq = eq.subs(reps)
     return eq, {r: s for s, r in reps.items()}
 

--- a/sympy/simplify/tests/test_posify_assumptions.py
+++ b/sympy/simplify/tests/test_posify_assumptions.py
@@ -1,0 +1,47 @@
+from sympy import Symbol, posify
+
+
+def test_posify_preserves_compatible_assumptions():
+    cases = (
+        (Symbol('a_finite', finite=True), 'is_finite'),
+        (Symbol('a_integer', integer=True), 'is_integer'),
+        (Symbol('a_rational', rational=True), 'is_rational'),
+        (Symbol('a_even', even=True), 'is_even'),
+        (Symbol('a_odd', odd=True), 'is_odd'),
+        (Symbol('a_nonzero', nonzero=True), 'is_nonzero'),
+        (Symbol('a_nonnegative', nonnegative=True), 'is_nonnegative'),
+        (Symbol('a_real', real=True), 'is_real'),
+        (Symbol('a_complex', complex=True), 'is_complex'),
+    )
+
+    for sym, attr in cases:
+        posified, reps = posify(sym)
+
+        assert posified.is_positive is True
+        assert getattr(posified, attr) is True
+        assert reps == {posified: sym}
+
+
+def test_posify_skips_conflicting_assumptions():
+    conflicting = (
+        Symbol('m_negative', negative=True),
+        Symbol('m_nonpositive', nonpositive=True),
+        Symbol('m_zero', zero=True),
+        Symbol('m_imaginary', imaginary=True),
+        Symbol('m_prime', prime=True),
+    )
+
+    for sym in conflicting:
+        posified, reps = posify(sym)
+
+        assert posified == sym
+        assert reps == {}
+
+
+def test_posify_preserves_noncommutative():
+    nc = Symbol('nc', commutative=False)
+    posified, reps = posify(nc)
+
+    assert posified == nc
+    assert posified.is_commutative is False
+    assert reps == {}


### PR DESCRIPTION
## Summary
- preserve compatible Symbol assumptions when posifying and drop contradictions while forcing `positive=True`
- add regression coverage for assumption preservation, conflict skips, and noncommutative symbols
- Fixes #70

## Reproduction
1. PATH=/root/.local/bin:\$PATH python3 -m pytest sympy/simplify/tests/test_posify_assumptions.py::test_posify_preserves_compatible_assumptions

```
E           AssertionError: assert None is True
E            +  where None = getattr(_a_finite, 'is_finite')
```

## Testing
- PATH=/root/.local/bin:\$PATH python3 -m pytest sympy/simplify/tests/test_posify_assumptions.py