### PR TITLE
swev-id: sympy__sympy-16792 autowrap(cython): fix incorrect C signature for unused array args

### DIFF
--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -718,12 +718,24 @@ class CodeGen(object):
 
         if argument_sequence is not None:
             # if the user has supplied IndexedBase instances, we'll accept that
+            explicit_metadata = {}
             new_sequence = []
             for arg in argument_sequence:
+                metadata = {}
                 if isinstance(arg, IndexedBase):
-                    new_sequence.append(arg.label)
+                    symbol = arg.label
+                    if arg.shape:
+                        dims = tuple((S.Zero, dim - 1) for dim in arg.shape)
+                        metadata['dimensions'] = dims
                 else:
-                    new_sequence.append(arg)
+                    symbol = arg
+                    if isinstance(arg, MatrixSymbol):
+                        dims = tuple((S.Zero, dim - 1) for dim in arg.shape)
+                        metadata['dimensions'] = dims
+
+                if metadata:
+                    explicit_metadata[symbol] = metadata
+                new_sequence.append(symbol)
             argument_sequence = new_sequence
 
             missing = [x for x in arg_list if x.name not in argument_sequence]
@@ -739,7 +751,8 @@ class CodeGen(object):
                 try:
                     new_args.append(name_arg_dict[symbol])
                 except KeyError:
-                    new_args.append(InputArgument(symbol))
+                    metadata = explicit_metadata.get(symbol, {})
+                    new_args.append(InputArgument(symbol, **metadata))
             arg_list = new_args
 
         return Routine(name, arg_list, return_val, local_vars, global_vars)

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 import shutil
 
-from sympy.core import symbols, Eq
+from sympy.core import symbols, Eq, S
 from sympy.core.compatibility import StringIO
 from sympy.utilities.autowrap import (autowrap, binary_function,
             CythonCodeWrapper, UfuncifyCodeWrapper, CodeWrapper)
@@ -184,6 +184,22 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
     assert setup_text == expected
 
     TmpFileManager.cleanup()
+
+
+def test_cython_wrapper_array_arg_not_in_expr():
+    from sympy import MatrixSymbol
+
+    x = MatrixSymbol('x', 2, 1)
+    routine = make_routine("autofunc", S.One, argument_sequence=(x,))
+
+    c_prototype = C99CodeGen().get_prototype(routine)
+    assert 'double *x' in c_prototype
+
+    cython_wrapper = CythonCodeWrapper(C99CodeGen())
+    source = get_string(cython_wrapper.dump_pyx, [routine])
+
+    assert "double *x" in source
+    assert "np.ndarray[np.double_t, ndim=2]" in source
 
 def test_cython_wrapper_unique_dummyvars():
     from sympy import Dummy, Equality


### PR DESCRIPTION
## Summary
- Fixes #73.
- Preserve array-shape metadata when `argument_sequence` explicitly lists matrix/indexed parameters that are absent from the expression so generated C/Cython signatures keep pointer types.
- Added regression coverage for the C prototype and Cython wrapper to ensure two-dimensional NumPy inputs are required.

## Root Cause
`CodeGen.routine()` created scalar `InputArgument` placeholders whenever `argument_sequence` referenced matrix-like arguments that were not part of the routine expression. Those placeholders lost their dimensional metadata so the downstream C/Cython wrappers emitted scalar parameters.

## Fix
Capture the declared shapes for explicit `MatrixSymbol`/`IndexedBase` entries when normalizing `argument_sequence`, and feed that metadata into synthetic `InputArgument`s. The resulting routines retain dimension information, keeping pointer signatures across generated wrappers.

## Reproduction Steps
1. python -m venv .venv && . .venv/bin/activate
2. pip install --upgrade pip && pip install cython numpy && pip install -e .
3. Ensure libstdc++ is on the runtime path (e.g. `export LD_LIBRARY_PATH=/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:$LD_LIBRARY_PATH`).
4. Run the reproducer:
   ```python
   from sympy.utilities.autowrap import autowrap
   from sympy import MatrixSymbol
   import numpy as np

   x = MatrixSymbol('x', 2, 1)
   expr = 1.0
   f = autowrap(expr, args=(x,), backend='cython')
   f(np.array([[1.0, 2.0]]))
   ```

### Observed Failure (before fix)
```
Wrapped function: <cyfunction autofunc_c at 0xffff93371480>
Invoking...
Traceback (most recent call last):
  File "<stdin>", line 10, in <module>
  File "wrapper_module_0.pyx", line 4, in wrapper_module_0.autofunc_c
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

## Verification
- . .venv/bin/activate && LD_LIBRARY_PATH=/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib bin/test sympy/utilities/tests/test_autowrap.py
- . .venv/bin/activate && LD_LIBRARY_PATH=/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib bin/test code_quality
- Manual: autowrap reproducer above now returns 1.0 without error.