### PR TITLE
PythonCodePrinter: add Indexed support (swev-id: sympy__sympy-16766)

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -363,13 +363,12 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
         Supports multiple indices as a single bracketed, comma-separated tuple
         (e.g., A[i, j]) and symbolic indices via self._print.
         """
-        base = expr.base
-        if hasattr(base, 'label'):
-            base_str = self._print(base.label)
-        else:
-            base_str = self._print(base)
+        base_str = self._print(expr.base)
         indices_str = ', '.join(self._print(index) for index in expr.indices)
         return '{}[{}]'.format(base_str, indices_str)
+
+    def _print_IndexedBase(self, expr):
+        return self._print(expr.label)
 
     def _print_Idx(self, expr):
         """Print index labels for Idx."""

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -357,6 +357,24 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
         PREC = precedence(expr)
         return self._operators['not'] + self.parenthesize(expr.args[0], PREC)
 
+    def _print_Indexed(self, expr):
+        """Print Python indexing for SymPy Indexed.
+
+        Supports multiple indices as a single bracketed, comma-separated tuple
+        (e.g., A[i, j]) and symbolic indices via self._print.
+        """
+        base = expr.base
+        if hasattr(base, 'label'):
+            base_str = self._print(base.label)
+        else:
+            base_str = self._print(base)
+        indices_str = ', '.join(self._print(index) for index in expr.indices)
+        return '{}[{}]'.format(base_str, indices_str)
+
+    def _print_Idx(self, expr):
+        """Print index labels for Idx."""
+        return self._print(expr.label)
+
 
 for k in PythonCodePrinter._kf:
     setattr(PythonCodePrinter, '_print_%s' % k, _print_known_func)

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -96,3 +96,19 @@ def test_NumPyPrinter_print_seq():
     n = NumPyPrinter()
 
     assert n._print_seq(range(2)) == '(0, 1,)'
+from sympy.tensor.indexed import Idx, IndexedBase
+
+def test_pycode_Indexed_simple():
+    base = IndexedBase('p')
+    result = pycode(base[0])
+    assert result == 'p[0]'
+    assert 'Not supported' not in result
+
+
+def test_pycode_Indexed_multi_and_symbolic_indices():
+    base = IndexedBase('A')
+    i, j = symbols('i j')
+    k = Idx('k')
+
+    assert pycode(base[i, j]) == 'A[i, j]'
+    assert pycode(base[i + j, k]) == 'A[i + j, k]'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -12,6 +12,7 @@ from sympy.printing.pycode import (
     MpmathPrinter, NumPyPrinter, PythonCodePrinter, pycode, SciPyPrinter
 )
 from sympy.utilities.pytest import raises
+from sympy.tensor.indexed import Idx, IndexedBase
 
 x, y, z = symbols('x y z')
 
@@ -96,7 +97,6 @@ def test_NumPyPrinter_print_seq():
     n = NumPyPrinter()
 
     assert n._print_seq(range(2)) == '(0, 1,)'
-from sympy.tensor.indexed import Idx, IndexedBase
 
 def test_pycode_Indexed_simple():
     base = IndexedBase('p')


### PR DESCRIPTION
Summary
- Add `_print_Indexed` and `_print_Idx` to PythonCodePrinter to correctly emit Python indexing for SymPy `Indexed` expressions.
- Add tests covering simple indexing and multi/symbolic indices.

Observed failure (pre-change)
Reproduction:

```
from sympy import *
p = IndexedBase("p")
from sympy.printing.pycode import pycode
print(pycode(p[0]))
```

Output:
```
  # Not supported in Python:
  # Indexed
p[0]
```

This banner is emitted because `PythonCodePrinter` lacks `_print_Indexed` and falls back to the generic not-supported path.

Stack trace
No exception is raised; the printer inserts a "Not supported in Python: Indexed" banner. There is no runtime stack trace; the issue manifests as incorrect/undesired code emission.

Fix
Implement:

```
# sympy/printing/pycode.py (in class PythonCodePrinter)
def _print_Indexed(self, expr):
    base = expr.base
    base_str = self._print(base.label) if hasattr(base, 'label') else self._print(base)
    indices_str = ', '.join(self._print(index) for index in expr.indices)
    return f"{base_str}[{indices_str}]"

def _print_Idx(self, expr):
    return self._print(expr.label)
```

Behavior after change
- `pycode(IndexedBase('p')[0])` -> `p[0]` (no banner)
- `pycode(IndexedBase('A')[Idx('i'), Idx('j')])` -> `A[i, j]`
- `pycode(IndexedBase('A')[symbols('i') + symbols('j'), Idx('k')])` -> `A[i + j, k]`

Tests
- Added to `sympy/printing/tests/test_pycode.py`:
  - `test_pycode_Indexed_simple`
  - `test_pycode_Indexed_multi_and_symbolic_indices`

Notes
- This change brings PythonCodePrinter to parity with other language printers that already support `Indexed`.
- We did not run CI as requested; local verification used Python 3.11 with mpmath installed.