### PR TITLE
geometry.Point: support scalar*Point (commutative); add __rmul__; fix addition asymmetry

### DIFF
--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -275,8 +275,33 @@ class Point(GeometryEntity):
         sympy.geometry.point.Point.scale
         """
         factor = sympify(factor)
+        # Only allow commutative scalar expressions to scale a point
+        if not isinstance(factor, Expr) or factor.is_commutative is not True:
+            raise TypeError("Point can only be scaled by a commutative scalar expression")
         coords = [simplify(x*factor) for x in self.args]
         return Point(coords, evaluate=False)
+
+    def __rmul__(self, factor):
+        """Right-multiply point's coordinates by a scalar factor.
+
+        Enable scalar*Point where the scalar is a commutative SymPy expression
+        (e.g., Integer, Rational, Float, Symbol) or Python numeric. This mirrors
+        __mul__ to ensure symmetry of scalar multiplication.
+
+        Examples
+        ========
+
+        >>> from sympy.geometry import Point
+        >>> from sympy import S, symbols
+        >>> p = Point(1, 2)
+        >>> 2*p
+        Point2D(2, 4)
+        >>> S(1)/2*p
+        Point2D(1/2, 1)
+        >>> symbols('a')*p
+        Point2D(a, 2*a)
+        """
+        return self.__mul__(factor)
 
     def __neg__(self):
         """Negate the point."""

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -119,6 +119,47 @@ def test_point():
     raises(ValueError, lambda: p.transform(Matrix([[1, 0], [0, 1]])))
 
 
+def test_point_scalar_multiplication_commutative_and_asymmetry_fix():
+    # Setup
+    p1 = Point(0, 0)
+    p2 = Point(1, 1)
+
+    # Integer
+    assert 2*p2 == Point(2, 2)
+    assert p2*2 == Point(2, 2)
+
+    # Rational
+    r = S(3)/2
+    assert r*p2 == Point(3/2, 3/2)
+    assert p2*r == Point(3/2, 3/2)
+
+    # Float (preserve Float exactness)
+    f = S(2).n()  # sympify(2.0)
+    res = f*p2
+    assert res == Point(2.0, 2.0)
+    assert p2*f == Point(2.0, 2.0)
+
+    # Symbolic commutative scalar
+    a = Symbol('a')
+    assert a*p2 == Point(a, a)
+    assert p2*a == Point(a, a)
+
+    # Addition with scalar*Point works in both orders
+    assert p1 + (p2*2) == Point(2, 2)
+    assert p1 + (2*p2) == Point(2, 2)
+
+    # Non-commutative Symbol should be rejected
+    nc = Symbol('nc', commutative=False)
+    from sympy.utilities.pytest import raises
+    raises(TypeError, lambda: nc*p2)
+    raises(TypeError, lambda: p2*nc)
+
+    # Non-scalar types like Matrix should be rejected
+    from sympy.matrices import Matrix
+    raises(TypeError, lambda: Matrix([[1, 0], [0, 1]])*p2)
+    raises(TypeError, lambda: p2*Matrix([[1, 0], [0, 1]]))
+
+
 def test_point3D():
     x = Symbol('x', real=True)
     y = Symbol('y', real=True)


### PR DESCRIPTION
This PR implements support for scalar*Point for commutative scalars and fixes the asymmetry reported in issue #83.

Changes
- Point.__rmul__ delegates to __mul__ to support left scalar multiplication.
- Point.__mul__ now validates that the factor is a commutative scalar Expr; raises TypeError for non-commutative or non-scalar types (e.g., Matrix).
- Added tests covering Integer, Rational, Float, and Symbol cases in both orders, addition symmetry, and rejection of non-commutative/non-scalar multipliers.

Why
- Previously, `Float*Point` produced a `Mul`, which caused `Point.__add__` to fail when attempting to convert the `Mul` to a `Point`. With this change, both `point + 2*other` and `point + other*2` work consistently.

Notes
- Exactness preserved: Integer/Rational keep rationals; Float yields float coordinates; symbolic scalars are preserved.

Base branch: sympy__sympy-17655