### PR TITLE
fix(matrices): preserve zero blocks (swev-id: sympy__sympy-17630)

### DIFF
--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from sympy import ask, Q
+from sympy import ask, Q, S
 from sympy.core import Basic, Add
 from sympy.core.compatibility import range
 from sympy.strategies import typed, exhaust, condition, do_one, unpack
@@ -164,7 +164,24 @@ class BlockMatrix(MatrixExpr):
     def _blockmul(self, other):
         if (isinstance(other, BlockMatrix) and
                 self.colblocksizes == other.rowblocksizes):
-            return BlockMatrix(self.blocks*other.blocks)
+            row_block_count, shared_block_count = self.blockshape
+            col_block_count = other.blockshape[1]
+            row_sizes = self.rowblocksizes
+            col_sizes = other.colblocksizes
+            result_blocks = []
+            for i in range(row_block_count):
+                for j in range(col_block_count):
+                    terms = [self.blocks[i, k] * other.blocks[k, j]
+                             for k in range(shared_block_count)]
+                    if not terms:
+                        block = ZeroMatrix(row_sizes[i], col_sizes[j])
+                    else:
+                        block = Add(*terms)
+                        if block is S.Zero:
+                            block = ZeroMatrix(row_sizes[i], col_sizes[j])
+                    result_blocks.append(block)
+            result_matrix = Matrix(row_block_count, col_block_count, result_blocks)
+            return BlockMatrix(result_matrix)
 
         return self * other
 

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -3,7 +3,7 @@ from sympy.matrices.expressions.blockmatrix import (
     BlockMatrix, bc_dist, bc_matadd, bc_transpose, bc_inverse,
     blockcut, reblock_2x2, deblock)
 from sympy.matrices.expressions import (MatrixSymbol, Identity,
-        Inverse, trace, Transpose, det)
+        Inverse, trace, Transpose, det, ZeroMatrix)
 from sympy.matrices import (
     Matrix, ImmutableMatrix, ImmutableSparseMatrix)
 from sympy.core import Tuple, symbols, Expr
@@ -146,6 +146,67 @@ def test_squareBlockMatrix():
 
     Z = BlockMatrix([[Identity(n), B], [C, D]])
     assert not Z.is_Identity
+
+
+def test_blockmul_preserves_zero_blocks_square():
+    a = MatrixSymbol('a', 2, 2)
+    z = ZeroMatrix(2, 2)
+    b = BlockMatrix([[a, z], [z, z]])
+
+    bb = b._blockmul(b)
+    assert bb.blocks[0, 0] == a**2
+    off_01 = bb.blocks[0, 1]
+    assert off_01.is_ZeroMatrix
+    assert off_01.shape == (2, 2)
+    off_10 = bb.blocks[1, 0]
+    assert off_10.is_ZeroMatrix
+    assert off_10.shape == (2, 2)
+    diag_11 = bb.blocks[1, 1]
+    assert diag_11.is_ZeroMatrix
+    assert diag_11.shape == (2, 2)
+
+    collapsed = block_collapse(b*b)
+    assert collapsed.blocks[0, 0] == a**2
+    assert collapsed.blocks[0, 1].is_ZeroMatrix
+    assert collapsed.blocks[0, 1].shape == (2, 2)
+    assert collapsed.blocks[1, 0].is_ZeroMatrix
+    assert collapsed.blocks[1, 0].shape == (2, 2)
+
+    triple = block_collapse(b*b*b)
+    assert triple.blocks[0, 0] == a**3
+    assert triple.blocks[0, 1].is_ZeroMatrix
+    assert triple.blocks[0, 1].shape == (2, 2)
+    assert triple.blocks[1, 0].is_ZeroMatrix
+    assert triple.blocks[1, 0].shape == (2, 2)
+    assert triple.blocks[1, 1].is_ZeroMatrix
+    assert triple.blocks[1, 1].shape == (2, 2)
+
+
+def test_blockmul_preserves_zero_blocks_rectangular():
+    x = MatrixSymbol('x', 2, 4)
+    y = MatrixSymbol('y', 4, 6)
+    lhs = BlockMatrix([[ZeroMatrix(2, 3), x],
+                       [ZeroMatrix(5, 3), ZeroMatrix(5, 4)]])
+    rhs = BlockMatrix([[ZeroMatrix(3, 6), ZeroMatrix(3, 1)],
+                       [y, ZeroMatrix(4, 1)]])
+
+    product = lhs._blockmul(rhs)
+    assert product.blocks[0, 0] == x*y
+    assert product.blocks[0, 1].is_ZeroMatrix
+    assert product.blocks[0, 1].shape == (2, 1)
+    assert product.blocks[1, 0].is_ZeroMatrix
+    assert product.blocks[1, 0].shape == (5, 6)
+    assert product.blocks[1, 1].is_ZeroMatrix
+    assert product.blocks[1, 1].shape == (5, 1)
+
+    collapsed = block_collapse(lhs*rhs)
+    assert collapsed.blocks[0, 0] == x*y
+    assert collapsed.blocks[0, 1].is_ZeroMatrix
+    assert collapsed.blocks[0, 1].shape == (2, 1)
+    assert collapsed.blocks[1, 0].is_ZeroMatrix
+    assert collapsed.blocks[1, 0].shape == (5, 6)
+    assert collapsed.blocks[1, 1].is_ZeroMatrix
+    assert collapsed.blocks[1, 1].shape == (5, 1)
 
 
 def test_BlockDiagMatrix():


### PR DESCRIPTION
## Summary
- implement explicit blockwise BlockMatrix multiplication that preserves zero block shapes and coerces scalar zeros
- add regression coverage for the issue reproduction and a rectangular block scenario
- ensure repeated products collapse cleanly and off-diagonals remain ZeroMatrix instances

Fixes #86

## Testing
- PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test sympy/matrices/expressions/tests/test_blockmatrix.py
- PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test code_quality