### PR TITLE
swev-id: sympy__sympy-17318 guard split_surds on empty surds

### DIFF
--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -1077,6 +1077,8 @@ def split_surds(expr):
     coeff_muls = [x.as_coeff_Mul() for x in args]
     surds = [x[1]**2 for x in coeff_muls if x[1].is_Pow]
     surds.sort(key=default_sort_key)
+    if not surds:
+        return S.One, S.Zero, expr
     g, b1, b2 = _split_gcd(*surds)
     g2 = g
     if not b2 and len(b1) >= 2:

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -4,7 +4,8 @@ from sympy import (
     Mul, radsimp, diff, root, Symbol, Rational, exp)
 
 from sympy.core.mul import _unevaluated_Mul as umul
-from sympy.simplify.radsimp import _unevaluated_Add, collect_sqrt, fraction_expand
+from sympy.simplify.radsimp import (
+    _unevaluated_Add, collect_sqrt, fraction_expand, split_surds)
 from sympy.utilities.pytest import XFAIL, raises
 
 from sympy.abc import x, y, z, a, b, c, d
@@ -423,3 +424,8 @@ def test_issue_14608():
     raises(AttributeError, lambda: collect(a*b + b*a, a))
     assert collect(x*y + y*(x+1), a) == x*y + y*(x+1)
     assert collect(x*y + y*(x+1) + a*b + b*a, y) == y*(2*x + 1) + a*b + b*a
+
+
+def test_split_surds_no_surds():
+    expr = S(2) + S(3) + S(5)
+    assert split_surds(expr) == (S.One, S.Zero, expr)

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -1,4 +1,4 @@
-from sympy import sqrt, root, S, Symbol, sqrtdenest, Integral, cos
+from sympy import sqrt, root, S, Symbol, sqrtdenest, Integral, cos, I
 from sympy.simplify.sqrtdenest import _subsets as subsets
 from sympy.utilities.pytest import slow
 
@@ -183,3 +183,8 @@ def test_issue_5653():
 
 def test_sqrt_ratcomb():
     assert sqrtdenest(sqrt(1 + r3) + sqrt(3 + 3*r3) - sqrt(10 + 6*r3)) == 0
+
+
+def test_sqrtdenest_issue_81_regression():
+    expr = (3 - sqrt(2)*sqrt(4 + 3*I) + 3*I)/2
+    assert sqrtdenest(expr) == expr


### PR DESCRIPTION
## Summary
- guard `split_surds` against an empty surd list so denesting defers to the original expression
- add regression coverage for `split_surds` and `sqrtdenest`
- Fixes #81

## Observed failure
Running `split_surds` on a sum that contains no surds raises `IndexError` on `sympy__sympy-17318`.

### Reproduction steps
```bash
python - <<'PY'
from sympy import S
from sympy.simplify.radsimp import split_surds
split_surds(S(2) + S(3) + S(5))
PY
```

### Stack trace
```
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "sympy/simplify/radsimp.py", line 1080, in split_surds
    g, b1, b2 = _split_gcd(*surds)
  File "sympy/simplify/radsimp.py", line 1116, in _split_gcd
    g = a[0]
IndexError: tuple index out of range
```

## Fix behavior
If `split_surds` cannot find any surd terms it now returns `(S.One, S.Zero, expr)` so callers like `sqrtdenest` leave the expression unchanged. Regression tests cover the guard and the reported expression `(3 - sqrt(2)*sqrt(4 + 3*I) + 3*I)/2`.

## Testing
- PATH=/root/.local/bin:$PATH python -m pytest sympy/simplify/tests/test_radsimp.py::test_split_surds_no_surds
- PATH=/root/.local/bin:$PATH python -m pytest sympy/simplify/tests/test_sqrtdenest.py::test_sqrtdenest_issue_81_regression
- PATH=/root/.local/bin:$PATH python -m pytest sympy/simplify/tests/test_radsimp.py
- PATH=/root/.local/bin:$PATH python -m pytest sympy/simplify/tests/test_sqrtdenest.py
- PATH=/root/.local/bin:$PATH bin/test code_quality