### PR TITLE
swev-id: sympy__sympy-17139 fix: avoid invalid exponent comparison in fu._TR56; add regression tests

### DIFF
--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -501,25 +501,30 @@ def _TR56(rv, f, g, h, max, pow):
         if not (rv.is_Pow and rv.base.func == f):
             return rv
 
-        if (rv.exp < 0) == True:
+        e = rv.exp
+
+        if e.is_extended_real is not True:
             return rv
-        if (rv.exp > max) == True:
+        if e.is_negative is True:
             return rv
-        if rv.exp == 2:
+        if e.is_number and e.is_real and e > max:
+            return rv
+        if e == 2:
             return h(g(rv.base.args[0])**2)
-        else:
-            if rv.exp == 4:
-                e = 2
+        if e.is_integer is True:
+            if e == 4:
+                power = 2
             elif not pow:
-                if rv.exp % 2:
+                if e % 2:
                     return rv
-                e = rv.exp//2
+                power = e//2
             else:
-                p = perfect_power(rv.exp)
+                p = perfect_power(e)
                 if not p:
                     return rv
-                e = rv.exp//2
-            return h(g(rv.base.args[0])**2)**e
+                power = e//2
+            return h(g(rv.base.args[0])**2)**power
+        return rv
 
     return bottom_up(rv, _f)
 

--- a/sympy/simplify/tests/test_trigsimp_complex_exponent.py
+++ b/sympy/simplify/tests/test_trigsimp_complex_exponent.py
@@ -1,0 +1,33 @@
+from sympy import I, cos, simplify, sin, symbols, tan, trigsimp
+
+
+def test_trigsimp_complex_exponent_no_change():
+    x = symbols('x')
+    expressions = [
+        cos(x) ** I,
+        sin(x) ** I,
+        (cos(x) + sin(x)) ** I,
+    ]
+
+    for expr in expressions:
+        assert simplify(expr) == expr
+        assert simplify(trigsimp(expr) - expr) == 0
+        assert simplify(trigsimp(expr, method='fu') - expr) == 0
+
+
+def test_trigsimp_integer_exponent_behaviour_preserved():
+    x = symbols('x')
+
+    assert simplify(trigsimp(cos(x) ** 2, method='fu') - (1 - sin(x) ** 2)) == 0
+    assert simplify(trigsimp(sin(x) ** 4, method='fu') - (1 - cos(x) ** 2) ** 2) == 0
+    assert simplify(trigsimp(1 / cos(x) ** 2 - 1, method='fu') - tan(x) ** 2) == 0
+
+
+def test_trigsimp_symbolic_non_integer_exponent_skipped():
+    x = symbols('x')
+    a = symbols('a', real=True)
+
+    assert simplify(trigsimp(cos(x) ** a) - cos(x) ** a) == 0
+    assert simplify(trigsimp(sin(x) ** a) - sin(x) ** a) == 0
+    assert trigsimp(cos(x) ** a, method='fu') == cos(x) ** a
+    assert trigsimp(sin(x) ** a, method='fu') == sin(x) ** a


### PR DESCRIPTION
## Summary
Fixes a `TypeError: Invalid comparison of complex I` raised during `simplify(cos(x)**I)` within the trigsimp/Fu pipeline.

- Harden `_TR56` in `sympy/simplify/fu.py` to use assumption-safe predicates for exponent checks and skip parity/perfect-power logic unless the exponent is an integer. This prevents invalid relational comparisons for non-real exponents.
- Add regression tests verifying that complex exponents pass unchanged and integer exponent behavior remains intact.

## Linked Issue
- https://github.com/agyn-sandbox/sympy/issues/82

## Reproduction (from issue)
```
from sympy import *
x = Symbol('x')
print(simplify(cos(x)**I))
```

## Stack trace (from issue)
```
File "/home/e/se/sympy/simplify/fu.py", line 504, in _f
    if (rv.exp < 0) == True:
File "/home/e/se/sympy/core/expr.py", line 406, in __lt__
    raise TypeError("Invalid comparison of complex %s" % me)
TypeError: Invalid comparison of complex I
```

## Notes
- The fix limits transformations to safe cases (real, integer exponents) and avoids changing behavior for symbolic non-integers.
- CI is not manually triggered per task instructions.