### PR TITLE
swev-id: sympy__sympy-18189 - forward permute flag in diophantine

### DIFF
--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -182,13 +182,13 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
             if syms != var:
                 dict_sym_index = dict(zip(syms, range(len(syms))))
                 return {tuple([t[dict_sym_index[i]] for i in var])
-                            for t in diophantine(eq, param)}
+                            for t in diophantine(eq, param, permute=permute)}
         n, d = eq.as_numer_denom()
         if n.is_number:
             return set()
         if not d.is_number:
-            dsol = diophantine(d)
-            good = diophantine(n) - dsol
+            dsol = diophantine(d, permute=permute)
+            good = diophantine(n, permute=permute) - dsol
             return {s for s in good if _mexpand(d.subs(zip(var, s)))}
         else:
             eq = n

--- a/sympy/solvers/tests/test_diophantine.py
+++ b/sympy/solvers/tests/test_diophantine.py
@@ -176,6 +176,18 @@ def test_issue_18138():
         assert not diop_simplify(eq.xreplace(dict(zip(v, sol))))
 
 
+def test_diophantine_permute_syms_order_consistency():
+    from sympy.abc import m, n
+    from sympy.solvers.diophantine import diophantine
+    from sympy.utilities.iterables import signed_permutations
+
+    eq = n**4 + m**4 - (2**4 + 3**4)
+    expected_mn = set(signed_permutations((2, 3)))
+    assert diophantine(eq, syms=(m, n), permute=True) == expected_mn
+    expected_nm = {(b, a) for (a, b) in expected_mn}
+    assert diophantine(eq, syms=(n, m), permute=True) == expected_nm
+
+
 @slow
 def test_quadratic_non_perfect_slow():
     assert check_solutions(8*x**2 + 10*x*y - 2*y**2 - 32*x - 13*y - 23)


### PR DESCRIPTION
## Summary
- forward the permute flag through recursive diophantine calls when syms order differs
- propagate permute handling across rational numerator/denominator solving
- add regression coverage for permute=True across symbol orderings

## Testing
- PATH=/root/.local/bin:$PATH python -m pytest sympy/solvers/tests/test_diophantine.py::test_diophantine_permute_syms_order_consistency
- PATH=/root/.local/bin:$PATH bin/test code_quality

Fixes #91