### PR TITLE
swev-id: sympy__sympy-18199 | nthroot_mod: include 0 when a % p == 0 (prime p)

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -770,17 +770,20 @@ def nthroot_mod(a, n, p, all_roots=False):
     a, n, p = as_int(a), as_int(n), as_int(p)
     if n == 2:
         return sqrt_mod(a, p, all_roots)
-    # For prime moduli, handle zero residue early to include 0 as a root
-    # and avoid incorrect processing in the multiplicative group of units.
+
+    residue_exists = is_nthpow_residue(a, n, p)
+
     if not isprime(p):
         raise NotImplementedError("Not implemented for composite p")
 
+    # For prime moduli, handle zero residue early to include 0 as a root
+    # and avoid incorrect processing in the multiplicative group of units.
     amod = a % p
     if amod == 0:
         return [0] if all_roots else 0
 
     # see Hackman "Elementary Number Theory" (2009), page 76
-    if not is_nthpow_residue(a, n, p):
+    if not residue_exists:
         return None
 
     if (p - 1) % n == 0:

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -776,15 +776,15 @@ def nthroot_mod(a, n, p, all_roots=False):
     if not isprime(p):
         raise NotImplementedError("Not implemented for composite p")
 
+    # see Hackman "Elementary Number Theory" (2009), page 76
+    if not residue_exists:
+        return None
+
     # For prime moduli, handle zero residue early to include 0 as a root
     # and avoid incorrect processing in the multiplicative group of units.
     amod = a % p
     if amod == 0:
         return [0] if all_roots else 0
-
-    # see Hackman "Elementary Number Theory" (2009), page 76
-    if not residue_exists:
-        return None
 
     if (p - 1) % n == 0:
         return _nthroot_mod1(a, n, p, all_roots)

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -770,11 +770,18 @@ def nthroot_mod(a, n, p, all_roots=False):
     a, n, p = as_int(a), as_int(n), as_int(p)
     if n == 2:
         return sqrt_mod(a, p, all_roots)
+    # For prime moduli, handle zero residue early to include 0 as a root
+    # and avoid incorrect processing in the multiplicative group of units.
+    if not isprime(p):
+        raise NotImplementedError("Not implemented for composite p")
+
+    amod = a % p
+    if amod == 0:
+        return [0] if all_roots else 0
+
     # see Hackman "Elementary Number Theory" (2009), page 76
     if not is_nthpow_residue(a, n, p):
         return None
-    if not isprime(p):
-        raise NotImplementedError("Not implemented for composite p")
 
     if (p - 1) % n == 0:
         return _nthroot_mod1(a, n, p, all_roots)

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -173,11 +173,13 @@ def test_residue():
     raises(NotImplementedError, lambda: nthroot_mod(16, 5, 36))
     raises(NotImplementedError, lambda: nthroot_mod(9, 16, 36))
 
-    # Zero residue cases: when p divides a, x ≡ 0 (mod p) is a root
+    # Zero residue cases: when p divides a, x == 0 (mod p) is a root
     assert nthroot_mod(17*17, 5, 17) == 0
     assert nthroot_mod(17*17, 5, 17, True) == [0]
     assert nthroot_mod(0, 3, 5) == 0
     assert nthroot_mod(0, 3, 5, True) == [0]
+    raises(ValueError, lambda: nthroot_mod(-17, 3, 17))
+    raises(ValueError, lambda: nthroot_mod(0, -1, 5))
     # p == 2
     assert nthroot_mod(14, 4, 2) == 0
     assert nthroot_mod(0, 7, 2, True) == [0]

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -178,6 +178,7 @@ def test_residue():
     assert nthroot_mod(17*17, 5, 17, True) == [0]
     assert nthroot_mod(0, 3, 5) == 0
     assert nthroot_mod(0, 3, 5, True) == [0]
+    assert nthroot_mod(0, 0, 5) is None
     raises(ValueError, lambda: nthroot_mod(-17, 3, 17))
     raises(ValueError, lambda: nthroot_mod(0, -1, 5))
     # p == 2

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -173,6 +173,21 @@ def test_residue():
     raises(NotImplementedError, lambda: nthroot_mod(16, 5, 36))
     raises(NotImplementedError, lambda: nthroot_mod(9, 16, 36))
 
+    # Zero residue cases: when p divides a, x ≡ 0 (mod p) is a root
+    assert nthroot_mod(17*17, 5, 17) == 0
+    assert nthroot_mod(17*17, 5, 17, True) == [0]
+    assert nthroot_mod(0, 3, 5) == 0
+    assert nthroot_mod(0, 3, 5, True) == [0]
+    # p == 2
+    assert nthroot_mod(14, 4, 2) == 0
+    assert nthroot_mod(0, 7, 2, True) == [0]
+    # n == 1 behaves as identity modulo p
+    assert nthroot_mod(100, 1, 5) == 0
+    assert nthroot_mod(6, 1, 7) == 6
+    assert nthroot_mod(6, 1, 7, True) == [6]
+    # Composite modulus remains NotImplemented
+    raises(NotImplementedError, lambda: nthroot_mod(0, 3, 9))
+
     for p in primerange(5, 100):
         qv = range(3, p, 4)
         for q in qv:


### PR DESCRIPTION
Summary

Fix nthroot_mod to include 0 as a solution when p divides a (for prime p). This prevents entering multiplicative-group logic (discrete logs) on s == 0, and returns 0 (or [0] with all_roots=True) as expected.

Linked Issue
- https://github.com/agyn-sandbox/sympy/issues/92

Observed failure and stack trace (before fix)
- Base: branch sympy__sympy-18199
- Repro:

```python
# Ensure mpmath is importable, then:
from sympy.ntheory.residue_ntheory import nthroot_mod
nthroot_mod(11*11, 5, 11)  # expecting 0
```

Stack trace:

```
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "sympy/ntheory/residue_ntheory.py", line 780, in nthroot_mod
    return _nthroot_mod1(a, n, p, all_roots)
  File "sympy/ntheory/residue_ntheory.py", line 728, in _nthroot_mod1
    t = discrete_log(p, s1, h)
  File "sympy/ntheory/residue_ntheory.py", line 1296, in discrete_log
    return _discrete_log_trial_mul(n, a, b, order)
  File "sympy/ntheory/residue_ntheory.py", line 1056, in _discrete_log_trial_mul
    raise ValueError("Log does not exist")
ValueError: Log does not exist
```

Changes
- sympy/ntheory/residue_ntheory.py: short-circuit for a % p == 0 after prime-check; return 0 or [0].
- sympy/ntheory/tests/test_residue.py: add tests covering zero residue cases for several p and n, n==1 identity behavior, and confirm composite modulus remains NotImplemented.

Testing
- Local: ran subset tests
  - PYTHONPATH set to include nix-provided mpmath site-packages.
  - `pytest sympy/ntheory/tests/test_residue.py -q` → 1 passed.
- CI: per request, no CI was triggered.

Notes
- Does not change composite-modulus behavior for nthroot_mod (still NotImplemented).
- This aligns nthroot_mod behavior with sqrt_mod, which already handles a ≡ 0.