### PR TITLE
fix: fallback ConditionSet for Relational.as_set (swev-id: sympy__sympy-18211)

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -392,7 +392,13 @@ class Relational(Boolean, EvalfMixin):
         syms = self.free_symbols
         assert len(syms) == 1
         x = syms.pop()
-        return solve_univariate_inequality(self, x, relational=False)
+        try:
+            return solve_univariate_inequality(self, x, relational=False)
+        except NotImplementedError:
+            from sympy import S
+            from sympy.sets.conditionset import ConditionSet
+
+            return ConditionSet(x, self, S.Reals)
 
     @property
     def binary_symbols(self):

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -8,6 +8,7 @@ from sympy.core.relational import (Relational, Equality, Unequality,
                                    StrictLessThan, Rel, Eq, Lt, Le,
                                    Gt, Ge, Ne)
 from sympy.sets.sets import Interval, FiniteSet
+from sympy.sets.conditionset import ConditionSet
 
 from itertools import combinations
 
@@ -425,6 +426,12 @@ def test_univariate_relational_as_set():
         Interval(0, oo, True, True)
 
     assert (x**2 >= 4).as_set() == Interval(-oo, -2) + Interval(2, oo)
+
+
+def test_relational_as_set_conditionset_fallback():
+    n = symbols('n', real=True)
+    expr = Eq(n*cos(n) - 3*sin(n), 0)
+    assert expr.as_set() == ConditionSet(n, expr, S.Reals)
 
 
 @XFAIL


### PR DESCRIPTION
## Summary
- catch `NotImplementedError` in `Relational._eval_as_set` and return a `ConditionSet` over the reals
- add regression coverage for transcendental equations while keeping existing behaviours intact

## Issue
- Closes #94

## Reproduction
1. python -m venv .venv && source .venv/bin/activate
2. pip install -U pip && pip install -e .
3. python - <<'PY'
from sympy import symbols, Eq, cos, sin
n = symbols('n', real=True)
Eq(n*cos(n) - 3*sin(n), 0).as_set()
PY

### Observed failure (pre-fix)
```
Traceback (most recent call last):
  File "/workspace/sympy/sympy/solvers/inequalities.py", line 524, in solve_univariate_inequality
    solns = solvify(e, gen, domain)
            ^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/sympy/sympy/solvers/solveset.py", line 2138, in solvify
    raise NotImplementedError('solveset is unable to solve this equation.')
NotImplementedError: solveset is unable to solve this equation.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File "/workspace/sympy/sympy/logic/boolalg.py", line 159, in as_set
    return self.subs(reps)._eval_as_set()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/sympy/sympy/core/relational.py", line 395, in _eval_as_set
    return solve_univariate_inequality(self, x, relational=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/sympy/sympy/solvers/inequalities.py", line 531, in solve_univariate_inequality
    raise NotImplementedError(filldedent('''
NotImplementedError: 
The inequality, Eq(x*cos(x) - 3*sin(x), 0), cannot be solved using
solve_univariate_inequality.
```

## Fix
- wrap the existing inequality solve in a try/except, returning `ConditionSet(x, self, S.Reals)` when solving is not implemented to preserve the general interface

## Testing
- source .venv/bin/activate && PATH="$PWD/.venv/bin:$PATH" bin/test sympy/core/tests/test_relational.py
- source .venv/bin/activate && PATH="$PWD/.venv/bin:$PATH" bin/test code_quality