### PR TITLE
srepr: print dict/set elements via srepr; handle empty set (swev-id: sympy__sympy-19346)

### DIFF
--- a/scripts/repro_srepr_dict_set_failure.py
+++ b/scripts/repro_srepr_dict_set_failure.py
@@ -1,0 +1,13 @@
+import sys
+sys.path.insert(0, '.')
+from sympy import symbols
+from sympy.printing import srepr
+x, y = symbols('x y')
+print('Actual srepr for set:', srepr({x, y}))
+print('Actual srepr for dict:', srepr({x: y}))
+# Expected recursive printing of Symbols
+expected_set_1 = "{Symbol('x'), Symbol('y')}"
+expected_set_2 = "{Symbol('y'), Symbol('x')}"
+expected_dict = "{Symbol('x'): Symbol('y')}"
+assert srepr({x, y}) in (expected_set_1, expected_set_2)
+assert srepr({x: y}) == expected_dict

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -144,6 +144,22 @@ class ReprPrinter(Printer):
     def _print_list(self, expr):
         return "[%s]" % self.reprify(expr, ", ")
 
+    def _print_set(self, expr):
+        """Print Python built-in set with srepr of elements.
+
+        Empty set must be represented as ``set()`` (``{}`` is an empty dict).
+        """
+        if len(expr) == 0:
+            return 'set()'
+        return "{" + self.reprify(expr, ", ") + "}"
+
+    def _print_dict(self, expr):
+        """Print Python built-in dict with srepr of keys and values."""
+        items = []
+        for k, v in expr.items():
+            items.append(f"{self._print(k)}: {self._print(v)}")
+        return "{" + ", ".join(items) + "}"
+
     def _print_MatrixBase(self, expr):
         # special case for some empty matrices
         if (expr.rows == 0) ^ (expr.cols == 0):

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -318,3 +318,25 @@ def test_diffgeom():
     assert srepr(rect) == "CoordSystem('rect', Patch('P', Manifold('M', 2)), ('rect_0', 'rect_1'))"
     b = BaseScalarField(rect, 0)
     assert srepr(b) == "BaseScalarField(CoordSystem('rect', Patch('P', Manifold('M', 2)), ('rect_0', 'rect_1')), Integer(0))"
+
+def test_set_and_dict():
+    # set: order can vary; accept either
+    s1 = "{Symbol('x'), Symbol('y')}"
+    s2 = "{Symbol('y'), Symbol('x')}"
+    assert srepr({x, y}) in (s1, s2)
+    assert eval(srepr({x, y}), ENV) == {x, y}
+
+    # empty set must not be printed as {}
+    assert srepr(set()) == "set()"
+    assert eval(srepr(set()), ENV) == set()
+
+    # dict: single item deterministic
+    assert srepr({x: y}) == "{Symbol('x'): Symbol('y')}"
+    assert eval(srepr({x: y}), ENV) == {x: y}
+
+    # dict with two items: order of items is insertion-ordered in py>=3.7
+    d = {x: y, y: x}
+    sA = "{Symbol('x'): Symbol('y'), Symbol('y'): Symbol('x')}"
+    sB = "{Symbol('y'): Symbol('x'), Symbol('x'): Symbol('y')}"
+    assert srepr(d) in (sA, sB)
+    assert eval(srepr(d), ENV) == d


### PR DESCRIPTION
Fixes srepr for Python dict and set so members/keys/values are printed using srepr, and ensures empty set prints as set().

Issue: https://github.com/agyn-sandbox/sympy/issues/100

Observed failure (before fix):

Use the following reproduction script against the base branch (sympy__sympy-19346):

```python
import sys
sys.path.insert(0, '.')
from sympy import symbols
from sympy.printing import srepr
x, y = symbols('x y')
print('Actual srepr for set:', srepr({x, y}))
print('Actual srepr for dict:', srepr({x: y}))
# Expected recursive printing of Symbols
expected_set_1 = "{Symbol('x'), Symbol('y')}"
expected_set_2 = "{Symbol('y'), Symbol('x')}"
expected_dict = "{Symbol('x'): Symbol('y')}"
assert srepr({x, y}) in (expected_set_1, expected_set_2)
assert srepr({x: y}) == expected_dict
```

Failure output seen on base branch:

```
Actual srepr for set: {y, x}
Actual srepr for dict: {x: y}
Traceback (most recent call last):
  File "scripts/repro_srepr_dict_set_failure.py", line 12, in <module>
    assert srepr({x, y}) in (expected_set_1, expected_set_2)
AssertionError
```

Fix details:
- Add _print_set to ReprPrinter to apply srepr to each element and print empty sets as set().
- Add _print_dict to ReprPrinter to apply srepr to keys and values.
- Add tests in sympy/printing/tests/test_repr.py for dict and set (including empty set and multi-item containers with order variations).

Reproduction steps:
1. On base branch sympy__sympy-19346, run the script above to see the failure.
2. On this PR branch, run the same code; you should see:
   - set: "{Symbol('x'), Symbol('y')}" (order may vary)
   - dict: "{Symbol('x'): Symbol('y')}"
3. Optional: run pytest for the new tests: `pytest -q sympy/printing/tests/test_repr.py::test_set_and_dict`.

Notes:
- CI is not triggered manually by this workflow.
