### PR TITLE
fix: swev-id: sympy__sympy-19495 guard bound substitutions

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2079,6 +2079,8 @@ class Lambda(Expr):
                 return self
 
             replacement = new
+            if replacement == old:
+                return self
             other_bound = set(bound) - {old}
             if replacement in other_bound or replacement in self.expr.free_symbols:
                 replacement = old.as_dummy()

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -43,7 +43,7 @@ from .numbers import Rational, Float
 from .operations import LatticeOp
 from .rules import Transform
 from .singleton import S
-from .sympify import sympify
+from .sympify import sympify, _sympify
 
 from sympy.core.containers import Tuple, Dict
 from sympy.core.parameters import global_parameters
@@ -111,6 +111,54 @@ class BadSignatureError(TypeError):
 class BadArgumentsError(TypeError):
     '''Raised when a Lambda is called with an incorrect number of arguments'''
     pass
+
+
+def bound_subs(expr, old, new):
+    """Return ``expr`` with ``old`` replaced by ``new`` outside bound scopes.
+
+    Subtrees whose ``bound_symbols`` contain ``old`` are left untouched so that
+    dummy variables keep their lexical scope during substitution.
+    """
+
+    old = _sympify(old)
+    new = _sympify(new)
+
+    if expr == old:
+        return new
+    if old == new:
+        return expr
+
+    def _recurse(node):
+        if node == old:
+            return new
+        if not isinstance(node, Basic):
+            return node
+
+        bound_syms = getattr(node, 'bound_symbols', ())
+        if bound_syms:
+            try:
+                if old in bound_syms:
+                    return node
+            except TypeError:
+                if any(old == sym for sym in bound_syms):
+                    return node
+
+        if not node._args:
+            return node
+
+        new_args = tuple(_recurse(arg) for arg in node._args)
+        if new_args == node._args:
+            return node
+        return node.func(*new_args)
+
+    return _recurse(expr)
+
+
+def _replace_signature_symbol(signature, target, replacement):
+    if isinstance(signature, Tuple):
+        return Tuple(*(_replace_signature_symbol(arg, target, replacement)
+                       for arg in signature))
+    return replacement if signature == target else signature
 
 
 # Python 2/3 version that does not raise a Deprecation warning
@@ -2020,6 +2068,31 @@ class Lambda(Expr):
     @property
     def free_symbols(self):
         return self.expr.free_symbols - set(self.variables)
+
+    def _eval_subs(self, old, new):
+        old = _sympify(old)
+        new = _sympify(new)
+
+        bound = tuple(self.variables)
+        if old in bound:
+            if not isinstance(new, Symbol):
+                return self
+
+            replacement = new
+            other_bound = set(bound) - {old}
+            if replacement in other_bound or replacement in self.expr.free_symbols:
+                replacement = old.as_dummy()
+
+            new_signature = _replace_signature_symbol(self.signature, old, replacement)
+            new_expr = bound_subs(self.expr, old, replacement)
+            if new_signature == self.signature and new_expr == self.expr:
+                return self
+            return self.func(new_signature, new_expr)
+
+        new_expr = bound_subs(self.expr, old, new)
+        if new_expr == self.expr:
+            return self
+        return self.func(self.signature, new_expr)
 
     def __call__(self, *args):
         n = len(args)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -283,6 +283,19 @@ def test_IdentityFunction():
     assert Lambda((x, y), x) is not S.IdentityFunction
 
 
+def test_lambda_bound_subs_alpha_conversion():
+    safe = Lambda(y, y + 1).subs(y, w)
+    assert safe == Lambda(w, w + 1)
+
+    capture = Lambda(y, y + z).subs(y, z)
+    dummy = capture.variables[0]
+    assert dummy.is_Dummy and dummy != z
+    assert capture == Lambda(dummy, dummy + z)
+
+    blocked = Lambda(y, y).subs(y, 1)
+    assert blocked == Lambda(y, y)
+
+
 def test_Lambda_symbols():
     assert Lambda(x, 2*x).free_symbols == set()
     assert Lambda(x, x*y).free_symbols == {y}

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -287,6 +287,9 @@ def test_lambda_bound_subs_alpha_conversion():
     safe = Lambda(y, y + 1).subs(y, w)
     assert safe == Lambda(w, w + 1)
 
+    same = Lambda(y, y + 1).subs(y, y)
+    assert same == Lambda(y, y + 1)
+
     capture = Lambda(y, y + z).subs(y, z)
     dummy = capture.variables[0]
     assert dummy.is_Dummy and dummy != z

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -4,7 +4,7 @@ from sympy import S
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
-from sympy.core.function import Lambda
+from sympy.core.function import Lambda, bound_subs
 from sympy.core.logic import fuzzy_bool
 from sympy.core.relational import Eq
 from sympy.core.symbol import Symbol, Dummy
@@ -214,37 +214,32 @@ class ConditionSet(Set):
         if old == sym:
             # we try to be as lenient as possible to allow
             # the dummy symbol to be changed
-            base = base.subs(old, new)
+            base = bound_subs(base, old, new)
             if isinstance(new, Symbol):
-                # if the assumptions don't match, the cond
-                # might evaluate or change
-                if (new.assumptions0 == old.assumptions0 or
-                        len(new.assumptions0) == 1 and
-                        old.is_commutative == new.is_commutative):
-                    if base != self.base_set:
-                        # it will be aggravating to have the dummy
-                        # symbol change if you are trying to target
-                        # the base set so if the base set is changed
-                        # leave the dummy symbol alone -- a second
-                        # subs will be needed to change the dummy
-                        return self.func(sym, cond, base)
-                    else:
-                        return self.func(new, cond.subs(old, new), base)
-                raise ValueError(filldedent('''
-                    A dummy symbol can only be
-                    replaced with a symbol having the same
-                    assumptions or one having a single assumption
-                    having the same commutativity.
-                '''))
+                if not (new.assumptions0 == sym.assumptions0 or
+                        (len(new.assumptions0) == 1 and
+                         sym.is_commutative == new.is_commutative)):
+                    raise ValueError(filldedent('''
+                        A dummy symbol can only be
+                        replaced with a symbol having the same
+                        assumptions or one having a single assumption
+                        having the same commutativity.
+                    '''))
+                if base != self.base_set:
+                    # Modifying the base set should not implicitly rename
+                    # the dummy symbol; require an additional substitution.
+                    return self.func(sym, cond, base)
+                cond = bound_subs(cond, old, new)
+                return self.func(new, cond, base)
             # don't target cond: it is there to tell how
             # the base set should be filtered and if new is not in
             # the base set then this substitution is ignored
             return self.func(sym, cond, base)
-        cond = self.condition.subs(old, new)
-        base = self.base_set.subs(old, new)
+        cond = bound_subs(cond, old, new)
+        base = bound_subs(base, old, new)
         if cond is S.true:
             return ConditionSet(new, Contains(new, base), base)
-        return self.func(self.sym, cond, base)
+        return self.func(sym, cond, base)
 
     def dummy_eq(self, other, symbol=None):
         if not isinstance(other, self.func):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -5,7 +5,7 @@ from functools import reduce
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
-from sympy.core.function import Lambda
+from sympy.core.function import Lambda, bound_subs
 from sympy.core.logic import fuzzy_not, fuzzy_or, fuzzy_and
 from sympy.core.numbers import oo, Integer
 from sympy.core.relational import Eq
@@ -493,6 +493,13 @@ class ImageSet(Set):
         if all(s.is_FiniteSet for s in self.base_sets):
             return FiniteSet(*(f(*a) for a in cartes(*self.base_sets)))
         return self
+
+    def _eval_subs(self, old, new):
+        new_lambda = self.lamda._subs(old, new)
+        new_sets = tuple(bound_subs(s, old, new) for s in self.base_sets)
+        if new_lambda is self.lamda and all(ns is bs for ns, bs in zip(new_sets, self.base_sets)):
+            return self
+        return self.func(new_lambda, *new_sets)
 
 
 class Range(Set):

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -1,7 +1,7 @@
 from sympy.sets import (ConditionSet, Intersection, FiniteSet,
-    EmptySet, Union, Contains)
+    EmptySet, Union, Contains, ImageSet)
 from sympy import (Symbol, Eq, S, Abs, sin, pi, Interval,
-    And, Mod, oo, Function)
+    And, Mod, oo, Function, Lambda)
 from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
 
 
@@ -128,6 +128,15 @@ def test_subs_CondSet():
         n, n < x, Interval(-oo, 0)).subs(x, p) == S.EmptySet
     assert ConditionSet(f(x), f(x) < 1, {w, z}
         ).subs(f(x), y) == ConditionSet(y, y < 1, {w, z})
+
+
+def test_subs_conditionset_preserves_bound_lambdas():
+    case_a = ConditionSet(x, Contains(x, ImageSet(Lambda(y, 2*y + y), S.Integers)), S.Reals)
+    assert case_a.subs(y, S(1)/3) == case_a
+
+    case_b = ConditionSet(y, Contains(y, ImageSet(Lambda(y, 2*y), S.Integers)), S.Reals)
+    assert case_b.subs(y, w) == ConditionSet(
+        w, Contains(w, ImageSet(Lambda(y, 2*y), S.Integers)), S.Reals)
 
 
 def test_subs_CondSet_tebr():

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -140,6 +140,12 @@ def test_ImageSet():
     raises(TypeError, lambda: ImageSet(Lambda(x, x**2), 1))
 
 
+def test_imageset_subs_free_parameter():
+    a = Symbol('a')
+    img = ImageSet(Lambda(t, t + a), S.Integers)
+    assert img.subs(a, 2) == ImageSet(Lambda(t, t + 2), S.Integers)
+
+
 def test_image_is_ImageSet():
     assert isinstance(imageset(x, sqrt(sin(x)), Range(5)), ImageSet)
 


### PR DESCRIPTION
## Summary
- add a bound-aware substitution helper shared by Lambda and set constructors
- prevent Lambda, ConditionSet, and ImageSet from mutating bound symbols during subs
- add regressions for ConditionSet/ImageSet scenarios and Lambda alpha-conversion

## Observed Failure
Case A from #104 raised `BadSignatureError` when substituting a numeric value into a nested ImageSet Lambda:
```
sympy.core.function.BadSignatureError: Lambda signature should be only tuples and symbols, not 1/3
  File sympy/core/basic.py, in _subs
  File sympy/core/function.py, in Lambda._check_signature
```

## Reproduction
```
python - <<'PY'
from sympy import Symbol, S, Lambda
from sympy.sets import ConditionSet, ImageSet
from sympy.sets.contains import Contains

x = Symbol('x')
y = Symbol('y')
w = Symbol('w')

case_a = ConditionSet(x, Contains(x, ImageSet(Lambda(y, 2*y + y), S.Integers)), S.Reals)
case_b = ConditionSet(y, Contains(y, ImageSet(Lambda(y, 2*y), S.Integers)), S.Reals)

print('A.subs(y, 1/3):', case_a.subs(y, S(1)/3))
print('B.subs(y, w):', case_b.subs(y, w))
PY
```
After this change, Case A stays unchanged and Case B only renames the outer dummy.

## Fix
- reuse a helper that skips subtrees binding the substitution target
- teach `Lambda._eval_subs` to block non-symbol replacements and alpha-convert when renaming
- switch ConditionSet and ImageSet to the helper so nested lambdas remain well-formed

## Testing
- `PATH=/root/.local/bin:$PATH python -m pytest sympy/core/tests/test_function.py`
- `PATH=/root/.local/bin:$PATH python -m pytest sympy/sets/tests/test_conditionset.py`
- `PATH=/root/.local/bin:$PATH python -m pytest sympy/sets/tests/test_fancysets.py`