### PR TITLE
swev-id: sympy__sympy-19040 preserve extension factors

### DIFF
--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -1152,7 +1152,7 @@ def dmp_ext_factor(f, u, K):
     factors = dmp_factor_list_include(r, u, K.dom)
 
     if len(factors) == 1:
-        factors = [f]
+        factors = [F]
     else:
         H = dmp_raise([K.one, s*K.unit], u, 0, K)
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6346,14 +6346,30 @@ def factor(f, *gens, **args):
                 partials[p] = fac
         return f.xreplace(partials)
 
+    extension_arg = args.get('extension', None)
+
     try:
-        return _generic_factor(f, gens, args, method='factor')
+        result = _generic_factor(f, gens, args, method='factor')
     except PolynomialError as msg:
         if not f.is_commutative:
             from sympy.core.exprtools import factor_nc
             return factor_nc(f)
         else:
             raise PolynomialError(msg)
+
+    if extension_arg and isinstance(extension_arg, (list, tuple)):
+        if not (result.is_Mul or result.is_Pow):
+            alt = factor(f, *gens)
+            if alt != result:
+                result = alt
+        quotient_expr = (f / result).cancel()
+        quotient_num, quotient_den = quotient_expr.as_numer_denom()
+        if quotient_den == 1:
+            quotient = quotient_num
+            if quotient != 1 and quotient.is_polynomial(*gens):
+                result = result * factor(quotient, *gens)
+
+    return result
 
 
 @public

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2465,6 +2465,23 @@ def test_factor():
 
     raises(FlagError, lambda: factor(x**2 - 1, polys=True))
 
+
+def test_factor_extension_I_multivariate_linear():
+    z = expand((x - 1)*(y - 1))
+
+    assert factor(z) == (x - 1)*(y - 1)
+    assert factor(z, extension=[I]) == (x - 1)*(y - 1)
+
+
+def test_factor_extension_I_multivariate_preserve_unrelated_factors():
+    z2 = expand((x - 1)*(y - 1)*(x + 2))
+
+    assert factor(z2, extension=[I]) == (x - 1)*(y - 1)*(x + 2)
+
+
+def test_factor_extension_univariate_no_regression():
+    assert factor(x**2 + 1, x, extension=I) == (x - I)*(x + I)
+
     assert factor([x, Eq(x**2 - y**2, Tuple(x**2 - z**2, 1/x + 1/y))]) == \
         [x, Eq((x - y)*(x + y), Tuple((x - z)*(x + z), (x + y)/x/y))]
 


### PR DESCRIPTION
## Summary
- fix dmp_ext_factor single-factor branch to retain the original polynomial for trial division
- add a defensive fallback in factor() so extension lists preserve rational factors instead of dropping them
- cover the regressions with multivariate and univariate extension tests

## Testing
- python3 -m pytest -q sympy/polys/tests/test_polytools.py::test_factor_extension_I_multivariate_linear sympy/polys/tests/test_polytools.py::test_factor_extension_I_multivariate_preserve_unrelated_factors sympy/polys/tests/test_polytools.py::test_factor_extension_univariate_no_regression sympy/polys/tests/test_polytools.py::test_factor
- PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:/root/.nix-profile/bin:$PATH bin/test sympy/polys/tests/test_polytools.py -k factor_extension

## Reproduction (pre-fix)
1. python3 -q
   ```pycon
   >>> from sympy import symbols, expand, factor, I
   >>> x, y = symbols('x y')
   >>> z = expand((x - 1)*(y - 1))
   >>> factor(z, extension=[I])
   x - 1
   ```
2. python3 -m pytest -q sympy/polys/tests/test_polytools.py::test_factor_extension_I_multivariate_linear

### Failing test assertion
```text
_________________ test_factor_extension_I_multivariate_linear __________________

    def test_factor_extension_I_multivariate_linear():
        z = expand((x - 1)*(y - 1))
    
        assert factor(z) == (x - 1)*(y - 1)
>       assert factor(z, extension=[I]) == (x - 1)*(y - 1)
E       assert x - 1 == ((x - 1) * (y - 1))
E        +  where x - 1 = factor(x*y - x - y + 1, extension=[I])

sympy/polys/tests/test_polytools.py:2473: AssertionError
```

Fixes #99