### PR TITLE
swev-id: sympy__sympy-19783 Fix dagger identity multiplication

### DIFF
--- a/sympy/physics/quantum/dagger.py
+++ b/sympy/physics/quantum/dagger.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 
-from sympy.core import Expr
+from sympy.core import Expr, Mul
 from sympy.functions.elementary.complexes import adjoint
 
 __all__ = [
@@ -84,6 +84,14 @@ class Dagger(adjoint):
         if obj is not None:
             return obj
         return Expr.__new__(cls, arg)
+
+    def __mul__(self, other):
+        from sympy.physics.quantum.operator import IdentityOperator
+
+        if isinstance(other, IdentityOperator):
+            return self
+
+        return Mul(self, other)
 
 adjoint.__name__ = "Dagger"
 adjoint._sympyrepr = lambda a, b: "Dagger(%s)" % b._print(a.args[0])

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -306,9 +306,15 @@ class IdentityOperator(Operator):
         return r'{\mathcal{I}}'
 
     def __mul__(self, other):
+        from sympy.physics.quantum.dagger import Dagger
 
         if isinstance(other, Operator):
             return other
+
+        if isinstance(other, Dagger):
+            base = other.args[0]
+            if isinstance(base, Operator):
+                return other
 
         return Mul(self, other)
 

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -106,6 +106,15 @@ def test_identity():
         assert represent(IdentityOperator(n)) == eye(n)
 
 
+def test_dagger_identity_multiplication():
+    A = Operator('A')
+    I = IdentityOperator()
+    B = Dagger(A)
+
+    assert B * I == B
+    assert I * B == B
+
+
 def test_outer_product():
     k = Ket('k')
     b = Bra('b')


### PR DESCRIPTION
## Summary
- Fixes #107 by covering IdentityOperator and Dagger interactions
- Return Dagger-wrapped operators when multiplying IdentityOperator by a daggered operator
- Ensure right-multiplication of Dagger by IdentityOperator leaves the Dagger unchanged

## Testing
- `PATH=/root/.local/bin:$PATH python3 -m pytest sympy/physics/quantum/tests/test_operator.py::test_dagger_identity_multiplication`
- `PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test sympy/physics/quantum`
- `PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test code_quality`

## Reproduction
### Steps
1. `PATH=/root/.local/bin:$PATH python3 -m pytest sympy/physics/quantum/tests/test_operator.py::test_dagger_identity_multiplication`

### Failure output
```
============================= test session starts ==============================
platform linux -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0
architecture: 64-bit
cache:        yes
ground types: python 

rootdir: /workspace/sympy
configfile: pytest.ini
collected 1 item

sympy/physics/quantum/tests/test_operator.py F                           [100%]

=================================== FAILURES ===================================
_____________________ test_dagger_identity_multiplication ______________________

    def test_dagger_identity_multiplication():
        A = Operator('A')
        I = IdentityOperator()
        B = Dagger(A)
    
>       assert B * I == B
E       assert (Dagger(A) * I) == Dagger(A)

sympy/physics/quantum/tests/test_operator.py:114: AssertionError
=============================== warnings summary ===============================
sympy/external/importtools.py:4
  /workspace/sympy/sympy/external/importtools.py:4: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils.version import LooseVersion

../../root/.local/lib/python3.11/site-packages/_pytest/config/__init__.py:1428
  /root/.local/lib/python3.11/site-packages/_pytest/config/__init__.py:1428: PytestConfigWarning: Unknown config option: doctestplus
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
                                DO *NOT* COMMIT!                                
=========================== short test summary info ============================
FAILED sympy/physics/quantum/tests/test_operator.py::test_dagger_identity_multiplication
======================== 1 failed, 2 warnings in 0.75s =========================
```