### PR TITLE
Fix partitions() to yield copies of dicts [swev-id: sympy__sympy-20154]

### DIFF
--- a/doc/src/modules/utilities/iterables.rst
+++ b/doc/src/modules/utilities/iterables.rst
@@ -45,7 +45,7 @@ of partions.
 partitions::
 
     >>> from sympy.utilities.iterables import partitions
-    >>> [p.copy() for s, p in partitions(7, m=2, size=True) if s == 2]
+    >>> [p for s, p in partitions(7, m=2, size=True) if s == 2]
     [{1: 1, 6: 1}, {2: 1, 5: 1}, {3: 1, 4: 1}]
 
 multiset_partitions::

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1738,19 +1738,16 @@ def partitions(n, m=None, k=None, size=False):
     {2: 1, 4: 1}
     {3: 2}
 
-    Note that the _same_ dictionary object is returned each time.
-    This is for speed:  generating each partition goes quickly,
-    taking constant time, independent of n.
+    The generator yields fresh dictionary objects on each iteration, so
+    the partitions can be collected directly:
 
     >>> [p for p in partitions(6, k=2)]
-    [{1: 6}, {1: 6}, {1: 6}, {1: 6}]
-
-    If you want to build a list of the returned dictionaries then
-    make a copy of them:
-
-    >>> [p.copy() for p in partitions(6, k=2)]  # doctest: +SKIP
     [{2: 3}, {1: 2, 2: 2}, {1: 4, 2: 1}, {1: 6}]
-    >>> [(M, p.copy()) for M, p in partitions(6, k=2, size=True)]  # doctest: +SKIP
+
+    When ``size`` is True, each item is a tuple containing the total number
+    of parts and the partition itself:
+
+    >>> list(partitions(6, k=2, size=True))  # doctest: +SKIP
     [(3, {2: 3}), (4, {1: 2, 2: 2}), (5, {1: 4, 2: 1}), (6, {1: 6})]
 
     References
@@ -1802,9 +1799,9 @@ def partitions(n, m=None, k=None, size=False):
         keys.append(r)
     room = m - q - bool(r)
     if size:
-        yield sum(ms.values()), ms
+        yield sum(ms.values()), dict(ms)
     else:
-        yield ms
+        yield dict(ms)
 
     while keys != [1]:
         # Reuse any 1's.
@@ -1842,9 +1839,9 @@ def partitions(n, m=None, k=None, size=False):
             break
         room -= need
         if size:
-            yield sum(ms.values()), ms
+            yield sum(ms.values()), dict(ms)
         else:
-            yield ms
+            yield dict(ms)
 
 
 def ordered_partitions(n, m=None, sort=True):

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -481,24 +481,43 @@ def test_partitions():
         assert list(partitions(6, None, 2, size=i)) != ans[i]
         assert list(partitions(6, 2, 0, size=i)) == ans[i]
 
-    assert [p.copy() for p in partitions(6, k=2)] == [
+    parts = list(partitions(6, k=2))
+    assert parts == [
         {2: 3}, {1: 2, 2: 2}, {1: 4, 2: 1}, {1: 6}]
+    assert len({id(p) for p in parts}) == len(parts)
 
-    assert [p.copy() for p in partitions(6, k=3)] == [
+    parts = list(partitions(6, k=3))
+    assert parts == [
         {3: 2}, {1: 1, 2: 1, 3: 1}, {1: 3, 3: 1}, {2: 3}, {1: 2, 2: 2},
         {1: 4, 2: 1}, {1: 6}]
+    assert len({id(p) for p in parts}) == len(parts)
 
-    assert [p.copy() for p in partitions(8, k=4, m=3)] == [
-        {4: 2}, {1: 1, 3: 1, 4: 1}, {2: 2, 4: 1}, {2: 1, 3: 2}] == [
-        i.copy() for i in partitions(8, k=4, m=3) if all(k <= 4 for k in i)
-        and sum(i.values()) <=3]
+    parts = list(partitions(8, k=4, m=3))
+    expected = [
+        {4: 2}, {1: 1, 3: 1, 4: 1}, {2: 2, 4: 1}, {2: 1, 3: 2}]
+    assert parts == expected
+    assert parts == [
+        i for i in partitions(8, k=4, m=3) if all(k <= 4 for k in i)
+        and sum(i.values()) <= 3]
+    assert len({id(p) for p in parts}) == len(parts)
 
-    assert [p.copy() for p in partitions(S(3), m=2)] == [
+    parts = list(partitions(S(3), m=2))
+    assert parts == [
         {3: 1}, {1: 1, 2: 1}]
+    assert len({id(p) for p in parts}) == len(parts)
 
-    assert [i.copy() for i in partitions(4, k=3)] == [
-        {1: 1, 3: 1}, {2: 2}, {1: 2, 2: 1}, {1: 4}] == [
-        i.copy() for i in partitions(4) if all(k <= 3 for k in i)]
+    parts = list(partitions(4, k=3))
+    expected = [
+        {1: 1, 3: 1}, {2: 2}, {1: 2, 2: 1}, {1: 4}]
+    assert parts == expected
+    assert parts == [
+        i for i in partitions(4) if all(k <= 3 for k in i)]
+    assert len({id(p) for p in parts}) == len(parts)
+
+    parts_with_size = list(partitions(6, k=2, size=True))
+    assert parts_with_size == [
+        (3, {2: 3}), (4, {1: 2, 2: 2}), (5, {1: 4, 2: 1}), (6, {1: 6})]
+    assert len({id(p) for _, p in parts_with_size}) == len(parts_with_size)
 
 
     # Consistency check on output of _partitions and RGS_unrank.
@@ -697,7 +716,7 @@ def test_reshape():
 
 
 def test_uniq():
-    assert list(uniq(p.copy() for p in partitions(4))) == \
+    assert list(uniq(p for p in partitions(4))) == \
         [{4: 1}, {1: 1, 3: 1}, {2: 2}, {1: 2, 2: 1}, {1: 4}]
     assert list(uniq(x % 2 for x in range(5))) == [0, 1]
     assert list(uniq('a')) == ['a']


### PR DESCRIPTION
## Summary
- ensure `partitions()` yields fresh dict objects and update docs/examples
- add regression coverage for aliasing and size=True tuples

## Issue
- Closes #109

## Reproduction
Before:



After:



## Testing
- PATH=/root/.local/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin pytest -q sympy/utilities/tests/test_iterables.py -k "partitions or uniq"
- PATH=/root/.local/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin bin/test code_quality}