### PR TITLE
Fix minimal_blocks deletion order causing sylow_subgroup IndexError (swev-id: sympy__sympy-19954)

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -2194,18 +2194,20 @@ class PermutationGroup(Basic):
                 # check if the system is minimal with
                 # respect to the already discovere ones
                 minimal = True
-                to_remove = []
+                idx_to_remove = []
                 for i, r in enumerate(rep_blocks):
                     if len(r) > len(rep) and rep.issubset(r):
                         # i-th block system is not minimal
-                        del num_blocks[i], blocks[i]
-                        to_remove.append(rep_blocks[i])
+                        idx_to_remove.append(i)
                     elif len(r) < len(rep) and r.issubset(rep):
                         # the system being checked is not minimal
                         minimal = False
                         break
-                # remove non-minimal representative blocks
-                rep_blocks = [r for r in rep_blocks if r not in to_remove]
+                if idx_to_remove:
+                    for index in reversed(idx_to_remove):
+                        del rep_blocks[index]
+                        del num_blocks[index]
+                        del blocks[index]
 
                 if minimal and num_block not in num_blocks:
                     blocks.append(block)

--- a/sympy/combinatorics/tests/test_perm_groups_sylow_blocks.py
+++ b/sympy/combinatorics/tests/test_perm_groups_sylow_blocks.py
@@ -1,0 +1,29 @@
+from sympy.combinatorics.named_groups import DihedralGroup, SymmetricGroup
+
+
+def _normalize_block_systems(blocks):
+    normalized = []
+    for block in blocks:
+        # block is a sequence describing block membership per point
+        normalized.append(tuple(block))
+    return set(normalized)
+
+
+def test_sylow_2_dihedral_even_orders():
+    assert DihedralGroup(18).sylow_subgroup(2).order() == 4
+    assert DihedralGroup(50).sylow_subgroup(2).order() == 4
+
+
+def test_minimal_blocks_dihedral6():
+    blocks = DihedralGroup(6).minimal_blocks(randomized=False)
+    assert len(blocks) == 2
+    normalized = _normalize_block_systems(blocks)
+    expected = {
+        (0, 1, 0, 1, 0, 1),
+        (0, 1, 2, 0, 1, 2),
+    }
+    assert normalized == expected
+
+
+def test_sylow_fallback_no_blocks():
+    assert SymmetricGroup(5).sylow_subgroup(3).order() == 3


### PR DESCRIPTION
## Summary
- defer block system removals until after iteration to keep minimal_blocks lists aligned
- add regression coverage for Sylow subgroups of even-order dihedral groups and minimal block enumeration
- ensure Sylow fallback path remains functional when no block systems arise

## Testing
- pytest sympy/combinatorics/tests -q

Fixes #111