### PR TITLE
Fix UnboundLocalError in kernS when no kern is inserted (swev-id: sympy__sympy-19637)

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -469,6 +469,7 @@ def kernS(s):
     from random import choice
     from sympy.core.symbol import Symbol
     hit = False
+    kern = None
     quoted = '"' in s or "'" in s
     if '(' in s and not quoted:
         if s.count('(') != s.count(")"):
@@ -513,7 +514,7 @@ def kernS(s):
             while kern in s:
                 kern += choice(string.ascii_letters + string.digits)
             s = s.replace(' ', kern)
-        hit = kern in s
+            hit = True
 
     for i in range(2):
         try:

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -510,6 +510,8 @@ def test_kernS():
     assert kernS('(1-2**-(4+1)*(1-y)*x)') == (1 - x*(1 - y)/32)
     assert kernS('(1-2**(4+1)*(1-y)*x)') == (1 - 32*x*(1 - y))
     assert kernS('(1-2.*(1-y)*x)') == 1 - 2.*x*(1 - y)
+    assert kernS('(2*x)/(x-1)') == sympify('(2*x)/(x-1)')
+    assert kernS('(x**2 + x)/(x-1)') == sympify('(x**2 + x)/(x-1)')
     one = kernS('x - (x - 1)')
     assert one != 1 and one.expand() == 1
 


### PR DESCRIPTION
## Summary
- initialize kern before use and only mark hit when substitution occurs
- add regression assertions for rational expressions wrapped with parentheses

## Testing
- PATH=/root/.local/bin:$PATH python3 -m pytest sympy/core/tests/test_sympify.py -k kernS -q

Fixes #116