### PR TITLE
fix: symmetric equality for Float vs BooleanFalse (swev-id: sympy__sympy-20801)

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1386,10 +1386,10 @@ class Float(Number):
             other = _sympify(other)
         except SympifyError:
             return NotImplemented
-        if not self:
-            return not other
         if isinstance(other, Boolean):
             return False
+        if not self:
+            return not other
         if other.is_NumberSymbol:
             if other.is_irrational:
                 return False

--- a/sympy/core/tests/test_bool_numeric_eq.py
+++ b/sympy/core/tests/test_bool_numeric_eq.py
@@ -1,0 +1,30 @@
+import pytest
+from sympy import S
+
+
+def test_boolean_float_zero_equality_is_symmetric():
+    # Reproduces current asymmetry:
+    # Before fix: S(0.0) == S.false is True, S.false == S(0.0) is False
+    # Expected after fix: both should be False
+    assert (S(0.0) == S.false) is False
+    assert (S.false == S(0.0)) is False
+
+
+def test_boolean_integer_zero_equality_is_symmetric():
+    assert (S(0) == S.false) is False
+    assert (S.false == S(0)) is False
+
+
+def test_boolean_true_numeric_non_equality():
+    assert (S(1.0) == S.true) is False
+    assert (S.true == S(1.0)) is False
+    assert (S(1) == S.true) is False
+    assert (S.true == S(1)) is False
+
+
+def test_numeric_equality_remains_correct():
+    assert (S(0.0) == S(0)) is True
+    assert (S(0) == S(0.0)) is True
+    assert (S(1.0) == S(1)) is True
+    assert (S(1) == S(1.0)) is True
+

--- a/sympy/core/tests/test_bool_numeric_eq.py
+++ b/sympy/core/tests/test_bool_numeric_eq.py
@@ -1,4 +1,3 @@
-import pytest
 from sympy import S
 
 
@@ -27,4 +26,3 @@ def test_numeric_equality_remains_correct():
     assert (S(0) == S(0.0)) is True
     assert (S(1.0) == S(1)) is True
     assert (S(1) == S(1.0)) is True
-


### PR DESCRIPTION
Summary
- Fix asymmetric equality between Float(0.0) and BooleanFalse.
- Ensure Booleans do not compare equal to Floats, aligning with Integer/Rational behavior.

Related issue: #120

Observed failure and reproduction
Before the fix, a minimal reproducer shows the asymmetry:

```py
from sympy import S
assert (S(0.0) == S.false) is False
```

Pytest run (pre-fix) output:

```text
F...                                                                     [100%]
=================================== FAILURES ===================================
________________ test_boolean_float_zero_equality_is_symmetric _________________

    def test_boolean_float_zero_equality_is_symmetric():
        # Reproduces current asymmetry:
        # Before fix: S(0.0) == S.false is True, S.false == S(0.0) is False
        # Expected after fix: both should be False
>       assert (S(0.0) == S.false) is False
E       assert (0.0 == False) is False
E        +  where 0.0 = S(0.0)
E        +  and   False = S.false

sympy/core/tests/test_bool_numeric_eq.py:9: AssertionError
```

Reproduction steps
1. Add the test file at `sympy/core/tests/test_bool_numeric_eq.py` (included in this PR).
2. Run (with Python 3.11 environment including mpmath):

```bash
PYTHONPATH=/nix/store/12f1jfj4mxz1f9xjk4lbhsfn7i9s7v7g-python3.11-mpmath-1.3.0/lib/python3.11/site-packages \
pytest -q sympy/core/tests/test_bool_numeric_eq.py
```

Implementation details
- File: `sympy/core/numbers.py`
- Change: In `Float.__eq__`, handle `Boolean` first, before zero short-circuiting. This prevents using Python truthiness on `BooleanFalse` when `self` is zero.

Tests added
- `sympy/core/tests/test_bool_numeric_eq.py` adds assertions ensuring:
  - `(S(0.0) == S.false) is False` and `(S.false == S(0.0)) is False`
  - Integer/Rational comparisons with booleans remain False in both directions
  - Numeric equality across integer/float types remains correct

Notes
- No CI run requested (per task rules).
- Base branch: `sympy__sympy-20801` (do not modify this branch directly).