### PR TITLE
swev-id: sympy__sympy-20590 | Printable: add empty __slots__ to restore slotted behavior

### DIFF
--- a/sympy/core/_print_helpers.py
+++ b/sympy/core/_print_helpers.py
@@ -17,6 +17,8 @@ class Printable:
     This also adds support for LaTeX printing in jupyter notebooks.
     """
 
+    __slots__ = ()
+
     # Note, we always use the default ordering (lex) in __str__ and __repr__,
     # regardless of the global setting. See issue 5487.
     def __str__(self):

--- a/sympy/core/tests/test_slots_printable.py
+++ b/sympy/core/tests/test_slots_printable.py
@@ -1,0 +1,30 @@
+import pytest
+
+from sympy import Symbol
+from sympy.core.basic import Basic
+from sympy.core._print_helpers import Printable
+from sympy.printing.str import sstr
+
+
+def test_symbol_instances_have_no_dict():
+    symbol = Symbol('s')
+
+    assert not hasattr(symbol, '__dict__')
+    with pytest.raises(AttributeError):
+        _ = symbol.__dict__
+
+
+def test_basic_instances_have_no_dict():
+    basic = Basic()
+
+    assert not hasattr(basic, '__dict__')
+    with pytest.raises(AttributeError):
+        _ = basic.__dict__
+
+
+def test_printable_declares_empty_slots():
+    assert Printable.__slots__ == ()
+
+
+def test_symbol_printing_is_unchanged():
+    assert sstr(Symbol('s')) == 's'


### PR DESCRIPTION
Closes #121

## Regression reproduction (1.7+)
```
from sympy import Symbol
s = Symbol('s')
hasattr(s, '__dict__')  # True before this fix
s.__dict__              # {}
```

## Expected behavior (1.6.2)
```
from sympy import Symbol
s = Symbol('s')
hasattr(s, '__dict__')  # False
s.__dict__              # AttributeError
```

## Root cause
`Printable` lacked `__slots__`, and `Basic` inherits it, introducing an instance `__dict__` in descendants.

## Fix
Add `__slots__ = ()` to `Printable`.

## Tests
`sympy/core/tests/test_slots_printable.py` confirm no `__dict__` for `Symbol`/`Basic`, `Printable` has empty slots, and printing unaffected.

## Note
This change is limited to restoring the historical behavior for `Basic` descendants. Classes combined with non-slotted bases (e.g., builtins, `DomainElement`) may still have an instance dict as before.