### PR TITLE
fix: swev-id: sympy__sympy-20916 support unicode digit suffix

### DIFF
--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -7,7 +7,8 @@ import re
 from collections.abc import Iterable
 from sympy import Derivative
 
-_name_with_digits_p = re.compile(r'^([a-zA-Z]+)([0-9]+)$')
+# Leading group matches Unicode letter characters (category L).
+_name_with_digits_p = re.compile(r'^([^\W\d_]+)([0-9]+)$', re.UNICODE)
 
 
 def split_super_sub(text):

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -291,6 +291,35 @@ def test_upretty_sub_super():
     assert upretty( Symbol("F^1^2^3^4") ) == 'F¹ ² ³ ⁴'
 
 
+def test_pretty_unicode_digit_suffix_symbols():
+    from io import StringIO
+    import sys
+
+    omega = "\N{GREEK SMALL LETTER OMEGA}"
+    sub_zero = "\N{SUBSCRIPT ZERO}"
+    sub_one = "\N{SUBSCRIPT ONE}"
+
+    cases = (
+        (Symbol(omega + "0"), omega + sub_zero),
+        (Symbol(omega + "1"), omega + sub_one),
+        (Symbol(omega + "10"), omega + sub_one + sub_zero),
+        (Symbol('w0'), 'w' + sub_zero),
+        (Symbol('w10'), 'w' + sub_one + sub_zero),
+    )
+
+    for sym_obj, expected in cases:
+        assert upretty(sym_obj) == expected
+
+        buffer = StringIO()
+        stdout = sys.stdout
+        sys.stdout = buffer
+        try:
+            pprint(sym_obj, use_unicode=True, wrap_line=False)
+        finally:
+            sys.stdout = stdout
+        assert buffer.getvalue() == expected + '\n'
+
+
 def test_upretty_subs_missing_in_24():
     assert upretty( Symbol('F_beta') ) == 'Fᵦ'
     assert upretty( Symbol('F_gamma') ) == 'Fᵧ'

--- a/sympy/printing/tests/test_conventions.py
+++ b/sympy/printing/tests/test_conventions.py
@@ -32,6 +32,19 @@ def test_super_sub():
     assert split_super_sub("") == ("", [], [])
 
 
+def test_super_sub_unicode_letters():
+    omega = "\N{GREEK SMALL LETTER OMEGA}"
+    cases = {
+        omega + "0": (omega, [], ["0"]),
+        omega + "1": (omega, [], ["1"]),
+        omega + "10": (omega, [], ["10"]),
+        "w0": ("w", [], ["0"]),
+        "w10": ("w", [], ["10"]),
+    }
+    for name, expected in cases.items():
+        assert split_super_sub(name) == expected
+
+
 def test_requires_partial():
     x, y, z, t, nu = symbols('x y z t nu')
     n = symbols('n', integer=True)


### PR DESCRIPTION
## Summary
- expand the split_super_sub letter matcher to include Unicode letters and document the regex
- add regression coverage for Greek symbols with digit suffixes in both conventions and pretty printers

## Issue
- Resolves #122

## Reproduction
1. `PYTHONPATH=/workspace/sympy python - <<'PY'
from sympy.printing.conventions import split_super_sub
for name in ['ω0','ω1','ω10','w0','w10']:
    print(name, '->', split_super_sub(name))
PY`

   Output before the fix:
   ```
   ω0 -> ('ω0', [], [])
   ω1 -> ('ω1', [], [])
   ω10 -> ('ω10', [], [])
   w0 -> ('w', [], ['0'])
   w10 -> ('w', [], ['10'])
   ```

## After Fix
- Running the same snippet now yields:
  ```
  ω0 -> ('ω', [], ['0'])
  ω1 -> ('ω', [], ['1'])
  ω10 -> ('ω', [], ['10'])
  w0 -> ('w', [], ['0'])
  w10 -> ('w', [], ['10'])
  ```

## Testing
- `PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test sympy/printing/tests/test_conventions.py sympy/printing/pretty/tests/test_pretty.py`

  ```
  146 passed, 1 expected to fail
  ```