### PR TITLE
fix: ProductSet subset FiniteSet handling (swev-id: sympy__sympy-20438)

### DIFF
--- a/sympy/sets/handlers/issubset.py
+++ b/sympy/sets/handlers/issubset.py
@@ -1,7 +1,7 @@
 from sympy import S, Symbol
 from sympy.core.logic import fuzzy_and, fuzzy_bool, fuzzy_not, fuzzy_or
 from sympy.core.relational import Eq
-from sympy.sets.sets import FiniteSet, Interval, Set, Union
+from sympy.sets.sets import FiniteSet, Interval, ProductSet, Set, Union
 from sympy.sets.fancysets import Complexes, Reals, Range, Rationals
 from sympy.multipledispatch import dispatch
 
@@ -73,6 +73,7 @@ def is_subset_sets(a_range, b_finiteset): # noqa:F811
     except ValueError:
         # symbolic Range of unknown size
         return None
+
     if a_size > len(b_finiteset):
         return False
     elif any(arg.has(Symbol) for arg in a_range.args):
@@ -99,6 +100,45 @@ def is_subset_sets(a_range, b_finiteset): # noqa:F811
             if len(a_set) == 0:
                 return True
         return None
+
+@dispatch(ProductSet, FiniteSet)  # type: ignore # noqa:F811
+def is_subset_sets(product, finite):  # noqa:F811
+    product_is_finite = product.is_finite_set
+    if product_is_finite is False:
+        return False
+
+    finite_size = len(finite)
+
+    try:
+        product_size = len(product)
+    except (TypeError, ValueError, NotImplementedError):
+        product_size = None
+
+    if product_size is not None:
+        if product_size > finite_size:
+            return False
+        if product_size == finite_size:
+            comparison = finite.is_subset(product)
+            if comparison is True:
+                return True
+            if comparison is False:
+                return False
+
+    if product_is_finite is not True:
+        return None
+
+    try:
+        for element in product:
+            contains = finite._contains(element)
+            if contains in (True, S.true):
+                continue
+            if contains in (False, S.false):
+                return False
+            return None
+    except (TypeError, ValueError, NotImplementedError):
+        return None
+
+    return True
 
 @dispatch(Interval, Range)  # type: ignore # noqa:F811
 def is_subset_sets(a_interval, b_range): # noqa:F811

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -618,6 +618,36 @@ def test_ProductSet():
     assert Contains((1, 2), Z2) is S.true
 
 
+def test_ProductSet_is_subset_FiniteSet_cases():
+    # Regression for agyn-sandbox/sympy#118
+    A = FiniteSet(1, 2)
+    product_square = ProductSet(A, A)
+
+    assert product_square.is_subset(
+        FiniteSet((1, 1), (1, 2), (2, 1), (2, 2))
+    ) is True
+
+    assert product_square.is_subset(
+        FiniteSet((1, 1), (1, 2), (2, 1))
+    ) is False
+
+    assert product_square.is_subset(
+        FiniteSet((1, 1), (1, 2), (2, 1), (2, 2), (-1, -1))
+    ) is True
+
+    infinite_factor = ProductSet(S.Integers, A)
+    assert infinite_factor.is_subset(FiniteSet((1, 1))) is False
+
+    symbolic_square = ProductSet(FiniteSet(x), FiniteSet(1))
+    assert symbolic_square.is_subset(FiniteSet((y, 1))) is None
+
+    nested_product = ProductSet(ProductSet(FiniteSet(1), FiniteSet(2)), FiniteSet(3))
+    assert nested_product.is_subset(FiniteSet(((1, 2), 3))) is True
+
+    cardinality_gap = ProductSet(FiniteSet(1, 2), FiniteSet(3, 4))
+    assert cardinality_gap.is_subset(FiniteSet((1, 3), (1, 4), (2, 3))) is False
+
+
 def test_ProductSet_of_single_arg_is_not_arg():
     assert unchanged(ProductSet, Interval(0, 1))
     assert unchanged(ProductSet, ProductSet(Interval(0, 1)))


### PR DESCRIPTION
## Summary
- add a ProductSet vs FiniteSet multipledispatch handler with finiteness and cardinality pruning
- reuse FiniteSet subset checks for equal-cardinality comparisons and return None when undecidable
- add regression coverage for finite, infinite, symbolic, nested, and cardinality gap scenarios (#118)

## Testing
- `PYTHONPATH=/workspace/pythoncompat:/workspace/sympy PATH=/root/.local/bin:$PATH bin/test sympy/sets/tests/test_sets.py` (96 passed, 4 expected to fail)
- `PYTHONPATH=/workspace/pythoncompat:/workspace/sympy PATH=/root/.local/bin:$PATH bin/test code_quality` (7 passed)

## Observed failure
```python
>>> a = FiniteSet(1, 2)
>>> b = ProductSet(a, a)
>>> c = FiniteSet((1, 1), (1, 2), (2, 1), (2, 2))
>>> b.is_subset(c)
>>> c.is_subset(b)
True
```

## Stack trace
```
>>> Eq(b, c).simplify()
Traceback (most recent call last):
  File ".../code.py", line 91, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File ".../sympy/core/basic.py", line 1655, in simplify
    return simplify(self, **kwargs)
  File ".../sympy/simplify/simplify.py", line 559, in simplify
    return _eval_simplify(**kwargs)
  File ".../sympy/core/relational.py", line 646, in _eval_simplify
    e = super(Equality, self)._eval_simplify(**kwargs)
  File ".../sympy/core/relational.py", line 308, in _eval_simplify
    elif dif.equals(0):  # XXX this is expensive
AttributeError: 'Complement' object has no attribute 'equals'
```

## Reproduction steps
1. Start a Python REPL.
2. Execute the snippet shown in **Observed failure** to reproduce the incorrect `None` result and the crash above.