### PR TITLE
swev-id: sympy__sympy-21379 catch PolynomialError in Mod gcd

### DIFF
--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -40,6 +40,7 @@ class Mod(Function):
         from sympy.core.mul import Mul
         from sympy.core.singleton import S
         from sympy.core.exprtools import gcd_terms
+        from sympy.polys.polyerrors import PolynomialError
         from sympy.polys.polytools import gcd
 
         def doit(p, q):
@@ -166,7 +167,10 @@ class Mod(Function):
         # XXX other possibilities?
 
         # extract gcd; any further simplification should be done by the user
-        G = gcd(p, q)
+        try:
+            G = gcd(p, q)
+        except PolynomialError:
+            G = S.One
         if G != 1:
             p, q = [
                 gcd_terms(i/G, clear=False, fraction=False) for i in (p, q)]

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1,7 +1,7 @@
 from sympy import (Basic, Symbol, sin, cos, atan, exp, sqrt, Rational,
         Float, re, pi, sympify, Add, Mul, Pow, Mod, I, log, S, Max, symbols,
         oo, zoo, Integer, sign, im, nan, Dummy, factorial, comp, floor, Poly,
-        FiniteSet
+        FiniteSet, Piecewise, sinh, cosh, tanh, nfloat
 )
 from sympy.core.parameters import distribute
 from sympy.core.expr import unchanged
@@ -1912,6 +1912,42 @@ def test_Mod():
     # rewrite
     assert Mod(x, y).rewrite(floor) == x - y*floor(x/y)
     assert ((x - Mod(x, y))/y).rewrite(floor) == floor(x/y)
+
+
+def test_Mod_piecewise_no_exception():
+    pw = Piecewise((x, y > x), (y, True))
+    expr = Mod(pw/z, 1)
+    assert expr.func is Mod
+    assert expr.args == (pw/z, S.One)
+
+
+def test_Mod_piecewise_divisor_no_exception():
+    pw = Piecewise((2, y > x), (3, True))
+    expr = Mod(x, pw)
+    assert expr.func is Mod
+    assert expr.args[1].func is Piecewise
+
+
+def test_hyperbolic_piecewise_subs_no_exception():
+    x, y, z = symbols('x y z', real=True)
+    pw = Piecewise((x, y > x), (y, True))
+    for fun in (sinh, cosh, tanh):
+        expr = exp(fun(pw/z))
+        result = expr.subs({1: 1.0})
+        assert result.free_symbols == {x, y, z}
+
+
+def test_hyperbolic_piecewise_nfloat_no_exception():
+    x, y, z = symbols('x y z', real=True)
+    pw = Piecewise((x, y > x), (y, True))
+    for fun in (sinh, cosh, tanh):
+        expr = exp(fun(pw/z))
+        result = nfloat(expr)
+        assert result.free_symbols == {x, y, z}
+
+
+def test_Mod_gcd_simplification_non_piecewise_regression():
+    assert (12*x) % (15*x*y) == 3*x*Mod(4, 5*y)
 
 
 def test_Mod_Pow():


### PR DESCRIPTION
## Summary
- catch PolynomialError around `gcd` in `Mod.eval` and fall back to `S.One`
- add regression coverage for Piecewise-based arguments hitting Mod via substitutions and numeric casts

## Issue
- Fixes #123

## Observed failure
Calling `expr.subs({1: 1.0})` on `exp(sinh(Piecewise((x, y > x), (y, True)) / z))` with real symbols raised `PolynomialError: Piecewise generators do not make sense`.

### Reproduction
```python
from sympy import *
from sympy.core.cache import clear_cache

x, y, z = symbols('x y z')

clear_cache()
expr = exp(sinh(Piecewise((x, y > x), (y, True)) / z))
expr.subs({1: 1.0})

clear_cache()
x, y, z = symbols('x y z', real=True)
expr = exp(sinh(Piecewise((x, y > x), (y, True)) / z))
expr.subs({1: 1.0})  # PolynomialError
```

### Stack trace
```text
Traceback (most recent call last):
  File ".../sympy/core/assumptions.py", line 454, in getit
    return self._assumptions[fact]
KeyError: 'zero'
...
  File ".../sympy/functions/elementary/hyperbolic.py", line 251, in _eval_is_real
    return (im%pi).is_zero
  File ".../sympy/core/expr.py", line 280, in __mod__
    return Mod(self, other)
...
  File ".../sympy/core/mod.py", line 169, in eval
    G = gcd(p, q)
  File ".../sympy/polys/polytools.py", line 4399, in _parallel_poly_from_expr
    raise PolynomialError("Piecewise generators do not make sense")
PolynomialError: Piecewise generators do not make sense
```

## Testing
- `PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH python3 -m pytest sympy/core/tests/test_arit.py -k "Mod_piecewise or hyperbolic_piecewise or Mod_gcd_simplification_non_piecewise_regression"`

## Environment adjustments
- Installed python3.11 and pip from Nix; installed pytest and mpmath via pip for running tests.