### PR TITLE
swev-id: sympy__sympy-21612 Fix: preserve parentheses when printing nested denominators in str()

### DIFF
--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -324,5 +324,5 @@ def test_failing_not_parseable():
 def test_str_parentheses_for_nested_fracs():
     # Ensure that the string printer preserves parentheses for nested denominators
     from sympy.parsing.latex import parse_latex
-    assert str(parse_latex(r"rac{a}{rac{1}{b}}")) == "a/(1/b)"
-    assert str(parse_latex(r"rac{rac{a^3+b}{c}}{rac{1}{c^2}}")) == "((a**3 + b)/c)/(1/(c**2))"
+    assert str(parse_latex("\\frac{a}{\\frac{1}{b}}")) == "a/(1/b)"
+    assert str(parse_latex("\\frac{\\frac{a^3+b}{c}}{\\frac{1}{c^2}}")) == "((a**3 + b)/c)/(1/(c**2))"

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -319,3 +319,10 @@ def test_failing_not_parseable():
     for latex_str in FAILING_BAD_STRINGS:
         with raises(LaTeXParsingError):
             parse_latex(latex_str)
+
+
+def test_str_parentheses_for_nested_fracs():
+    # Ensure that the string printer preserves parentheses for nested denominators
+    from sympy.parsing.latex import parse_latex
+    assert str(parse_latex(r"rac{a}{rac{1}{b}}")) == "a/(1/b)"
+    assert str(parse_latex(r"rac{rac{a^3+b}{c}}{rac{1}{c^2}}")) == "((a**3 + b)/c)/(1/(c**2))"

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -296,7 +296,7 @@ class StrPrinter(Printer):
                 # must be parenthesized to preserve the intended structure.
                 # See issue sympy__sympy-21612 where expressions like a/(1/b)
                 # were being printed as a/1/b.
-                if '/' in d:
+                if '/' in d and not (d.startswith('(') and d.endswith(')')):
                     return '%s/(%s)' % (n, d)
                 return '%s/%s' % (n, d)
             return n
@@ -367,7 +367,7 @@ class StrPrinter(Printer):
             # If the single denominator renders with a division (e.g. '1/b'),
             # wrap it in parentheses to preserve the intended grouping.
             denom = b_str[0]
-            if '/' in denom:
+            if '/' in denom and not (denom.startswith('(') and denom.endswith(')')):
                 return sign + '*'.join(a_str) + "/(" + denom + ")"
             return sign + '*'.join(a_str) + "/" + denom
         else:

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -292,6 +292,12 @@ class StrPrinter(Printer):
             if len(dfactors) > 1:
                 return '%s/(%s)' % (n, d)
             elif dfactors:
+                # If the (single) denominator itself contains a division, it
+                # must be parenthesized to preserve the intended structure.
+                # See issue sympy__sympy-21612 where expressions like a/(1/b)
+                # were being printed as a/1/b.
+                if '/' in d:
+                    return '%s/(%s)' % (n, d)
                 return '%s/%s' % (n, d)
             return n
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -364,7 +364,12 @@ class StrPrinter(Printer):
         if not b:
             return sign + '*'.join(a_str)
         elif len(b) == 1:
-            return sign + '*'.join(a_str) + "/" + b_str[0]
+            # If the single denominator renders with a division (e.g. '1/b'),
+            # wrap it in parentheses to preserve the intended grouping.
+            denom = b_str[0]
+            if '/' in denom:
+                return sign + '*'.join(a_str) + "/(" + denom + ")"
+            return sign + '*'.join(a_str) + "/" + denom
         else:
             return sign + '*'.join(a_str) + "/(%s)" % '*'.join(b_str)
 


### PR DESCRIPTION
Fixes incorrect string printing for nested fractions like a/(1/b), which printed as a/1/b.

Summary
- Root cause: The str printer for Mul did not parenthesize a single denominator that itself renders with a division (e.g., 1/b). This is a printing (not parsing) defect.
- Change: In StrPrinter._print_Mul, parenthesize a single denominator if its rendered form contains a '/' and is not already wrapped. Applied to both the unevaluated-Mul path and the general path. Also avoid double-wrapping if already parenthesized.
- Tests: Added parsing/latex tests asserting the desired string outputs for the reported cases.

Reproduction (before fix)
Using Python 3.12 with antlr4-python3-runtime==4.7.2 in a venv, and running from the repo source (PYTHONPATH pointing to sympy):

```
>>> from sympy.parsing.latex import parse_latex
>>> parse_latex("\\frac{a}{\\frac{1}{b}}")
a/1/b
>>> parse_latex("\\frac{\\frac{a^3+b}{c}}{\\frac{1}{c^2}}")
((a**3 + b)/c)/1/(c**2)
>>> parse_latex("\\frac{a}{\\frac{b}{c}}")
a/((b/c))
```

Observed failure and stack trace (when testing initially, due to Python string literal mishandling we hit a LaTeXParsingError showing a formfeed; the underlying issue however is the missing parentheses during printing):

```
LaTeXParsingError: I don't understand this
\frac{a}{\frac{1}{b}}
^
```

After fix

```
>>> parse_latex("\\frac{a}{\\frac{1}{b}}")
a/(1/b)
>>> parse_latex("\\frac{\\frac{a^3+b}{c}}{\\frac{1}{c^2}}")
((a**3 + b)/c)/(1/(c**2))
>>> parse_latex("\\frac{a}{\\frac{b}{c}}")
a/((b/c))
```

Notes
- This addresses the behavior reported in issue #130 in this repo.
- CI should not be manually triggered as per instructions. This PR targets base branch sympy__sympy-21612.