### PR TITLE
swev-id: sympy__sympy-21596 fix imageset ∩ Reals

### DIFF
--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -290,36 +290,61 @@ def intersection_sets(self, other): # noqa:F811
         im = expand_complex(im)
 
         re = re.subs(n_, n)
-        im = im.subs(n_, n)
-        ifree = im.free_symbols
+        im = expand_complex(im.subs(n_, n))
         lam = Lambda(n, re)
+
+        restricted_base = base_set
+
         if im.is_zero:
-            # allow re-evaluation
-            # of self in this case to make
-            # the result canonical
-            pass
+            restricted_base = base_set
         elif im.is_zero is False:
             return S.EmptySet
-        elif ifree != {n}:
+        elif im.free_symbols - {n}:
             return None
         else:
-            # univarite imaginary part in same variable
-            x, xis = zip(*[solve_linear(i, 0) for i in Mul.make_args(im) if n in i.free_symbols])
-            if x and all(i == n for i in x):
-                base_set -= FiniteSet(xis)
-            else:
-                base_set -= ConditionSet(n, Eq(im, 0), S.Integers)
-        # exclude values that make denominators 0
-        for i in denoms(f):
-            if i.has(n):
-                sol = list(zip(*[solve_linear(i, 0) for i in Mul.make_args(im) if n in i.free_symbols]))
-                if sol != []:
-                    x, xis = sol
-                    if x and all(i == n for i in x):
-                        base_set -= FiniteSet(xis)
+            factors = [factor for factor in Mul.make_args(im) if factor.has(n)]
+            solutions = []
+            linear_only = True
+            for factor in factors:
+                try:
+                    var, sol = solve_linear(factor, 0)
+                except (ValueError, NotImplementedError):
+                    var = sol = None
+                if var == n:
+                    solutions.append(sol)
                 else:
-                    base_set -= ConditionSet(n, Eq(i, 0), S.Integers)
-        return imageset(lam, base_set)
+                    linear_only = False
+                    break
+            if linear_only and solutions:
+                restricted_base = restricted_base.intersect(FiniteSet(*solutions))
+            else:
+                restricted_base = restricted_base.intersect(
+                    ConditionSet(n, Eq(im, 0), base_set))
+
+        for denom in denoms(f):
+            if not denom.has(n):
+                continue
+            denom_factors = [factor for factor in Mul.make_args(denom) if factor.has(n)]
+            if not denom_factors:
+                continue
+            denom_solutions = []
+            denom_linear_only = True
+            for factor in denom_factors:
+                try:
+                    var, sol = solve_linear(factor, 0)
+                except (ValueError, NotImplementedError):
+                    var = sol = None
+                if var == n:
+                    denom_solutions.append(sol)
+                else:
+                    denom_linear_only = False
+                    break
+            if denom_linear_only and denom_solutions:
+                restricted_base = restricted_base - FiniteSet(*denom_solutions)
+            else:
+                restricted_base = restricted_base - ConditionSet(n, Eq(denom, 0), base_set)
+
+        return imageset(lam, restricted_base)
 
     elif isinstance(other, Interval):
         from sympy.solvers.solveset import (invert_real, invert_complex,

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -7,6 +7,36 @@ from sympy.sets.fancysets import (Integers, Naturals, Reals, Range,
 from sympy.sets.sets import UniversalSet, imageset, ProductSet
 
 
+def _linear_solutions(expr, var):
+    """Return linear solutions for factors of ``expr`` in ``var``.
+
+    Returns a tuple ``(solutions, has_factors)`` where ``solutions`` is a
+    tuple of roots obtained from linear factors (empty if none) and
+    ``has_factors`` indicates whether any factors depending on ``var`` were
+    encountered. If a non-linear factor or solver failure is found, ``solutions``
+    is ``None`` and ``has_factors`` is ``True`` to signal the caller to fall
+    back on a ConditionSet."""
+
+    from sympy.solvers.solvers import solve_linear
+
+    factors = [factor for factor in Mul.make_args(expr) if factor.has(var)]
+    if not factors:
+        return tuple(), False
+
+    solutions = []
+    for factor in factors:
+        try:
+            solved_var, sol = solve_linear(factor, 0)
+        except (ValueError, NotImplementedError):
+            return None, True
+        if solved_var == var:
+            solutions.append(sol)
+        else:
+            return None, True
+
+    return tuple(solutions), True
+
+
 @dispatch(ConditionSet, ConditionSet)  # type: ignore # noqa:F811
 def intersection_sets(a, b): # noqa:F811
     return None
@@ -278,7 +308,7 @@ def intersection_sets(self, other): # noqa:F811
 
     if other == S.Reals:
         from sympy.core.function import expand_complex
-        from sympy.solvers.solvers import denoms, solve_linear
+        from sympy.solvers.solvers import denoms
         from sympy.core.relational import Eq
         f = self.lamda.expr
         n = self.lamda.variables[0]
@@ -302,20 +332,8 @@ def intersection_sets(self, other): # noqa:F811
         elif im.free_symbols - {n}:
             return None
         else:
-            factors = [factor for factor in Mul.make_args(im) if factor.has(n)]
-            solutions = []
-            linear_only = True
-            for factor in factors:
-                try:
-                    var, sol = solve_linear(factor, 0)
-                except (ValueError, NotImplementedError):
-                    var = sol = None
-                if var == n:
-                    solutions.append(sol)
-                else:
-                    linear_only = False
-                    break
-            if linear_only and solutions:
+            solutions, _ = _linear_solutions(im, n)
+            if solutions:
                 restricted_base = restricted_base.intersect(FiniteSet(*solutions))
             else:
                 restricted_base = restricted_base.intersect(
@@ -324,22 +342,10 @@ def intersection_sets(self, other): # noqa:F811
         for denom in denoms(f):
             if not denom.has(n):
                 continue
-            denom_factors = [factor for factor in Mul.make_args(denom) if factor.has(n)]
-            if not denom_factors:
+            denom_solutions, has_factors = _linear_solutions(denom, n)
+            if not has_factors:
                 continue
-            denom_solutions = []
-            denom_linear_only = True
-            for factor in denom_factors:
-                try:
-                    var, sol = solve_linear(factor, 0)
-                except (ValueError, NotImplementedError):
-                    var = sol = None
-                if var == n:
-                    denom_solutions.append(sol)
-                else:
-                    denom_linear_only = False
-                    break
-            if denom_linear_only and denom_solutions:
+            if denom_solutions:
                 restricted_base = restricted_base - FiniteSet(*denom_solutions)
             else:
                 restricted_base = restricted_base - ConditionSet(n, Eq(denom, 0), base_set)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -53,6 +53,24 @@ def test_imageset():
         Interval(1, 2), Interval(2, 3)))
 
 
+def test_imageset_intersect_reals():
+    n = symbols('n', integer=True)
+
+    s1 = imageset(Lambda(n, n + (n - 1)*(n + 1)*I), S.Integers)
+    assert s1.intersect(S.Reals) == FiniteSet(-1, 1)
+    assert (2 in s1.intersect(S.Reals)) is False
+
+    assert imageset(Lambda(n, n), S.Integers).intersect(S.Reals) == S.Integers
+
+    s2 = imageset(Lambda(n, n + I/(n - 1)), S.Integers)
+    assert s2.intersect(S.Reals) is S.EmptySet
+
+    s3 = imageset(Lambda(n, n + (n - 2)*(n - 3)*I), S.Integers)
+    assert s3.intersect(S.Reals) == FiniteSet(2, 3)
+
+    assert imageset(Lambda(n, 1/n), S.Integers).is_subset(S.Reals) is None
+
+
 def test_is_empty():
     for s in [S.Naturals, S.Naturals0, S.Integers, S.Rationals, S.Reals,
             S.UniversalSet]:


### PR DESCRIPTION
## Summary
- restrict ImageSet ∩ Reals to solutions of im == 0 and honour denominator exclusions
- represent non-linear imaginary zeros with ConditionSet against the original base domain
- add regression coverage for discrete and empty intersections plus neutral behaviour from #19513
- Applied minor refactor per deep review: shared `_linear_solutions` helper replaces duplicated loops.

## Reproduction
```python
In [8]: S1 = imageset(Lambda(n, n + (n - 1)*(n + 1)*I), S.Integers)
In [9]: S1
Out[9]: {n + ⅈ⋅(n - 1)⋅(n + 1) │ n ∊ ℤ}
In [10]: 2 in S1
Out[10]: False
In [11]: 2 in S1.intersect(Reals)
Out[11]: True
```

Observed failure (new regression test before fix):
```
_________ sympy/sets/tests/test_sets.py:test_imageset_intersect_reals __________
Traceback (most recent call last):
  File "sympy/sets/tests/test_sets.py", line 60, in test_imageset_intersect_reals
    assert s1.intersect(S.Reals) == FiniteSet(-1, 1)
AssertionError
```

Fixes #129

## Testing
- PATH=/root/.local/bin:$PATH bin/test sympy/sets/tests/test_sets.py
- PATH=/root/.local/bin:$PATH bin/test code_quality