### PR TITLE
fix: swev-id: sympy__sympy-21930 brace secondquant latex powers

### DIFF
--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -104,6 +104,16 @@ def test_create():
     assert o.apply_operator(BKet([n])) == o*BKet([n])
 
 
+def test_secondquant_latex_power_braces():
+    a, i = symbols('a i')
+    assert latex(Bd(i)) == r"b^\dagger_{i}"
+    assert latex(Bd(i)**2) == r"{b^\dagger_{i}}^{2}"
+    assert latex(Fd(i)**3) == r"{a^\dagger_{i}}^{3}"
+    assert latex(B(i)**2) == r"b_{i}^{2}"
+    comm_tex = latex(Commutator(Bd(a)**2, B(a)))
+    assert r"{b^\dagger_{a}}^{2}" in comm_tex
+
+
 def test_annihilate():
     i, j, n, m = symbols('i,j,n,m')
     o = B(i)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -638,6 +638,10 @@ class LatexPrinter(Printer):
                 base = self.parenthesize_super(base)
             if expr.base.is_Function:
                 return self._print(expr.base, exp="%s/%s" % (p, q))
+            if (not expr.base.is_Symbol
+                and "^" in base
+                and not (base.startswith('{') and base.endswith('}'))):
+                base = '{' + base + '}'
             return r"%s^{%s/%s}" % (base, p, q)
         elif expr.exp.is_Rational and expr.exp.is_negative and \
                 expr.base.is_commutative:
@@ -673,6 +677,10 @@ class LatexPrinter(Printer):
             and base.endswith(r'\right)')):
             # don't use parentheses around dotted derivative
             base = base[6: -7]  # remove outermost added parens
+        if (not expr.base.is_Symbol
+            and "^" in base
+            and not (base.startswith('{') and base.endswith('}'))):
+            base = '{' + base + '}'
         return template % (base, exp)
 
     def _print_UnevaluatedExpr(self, expr):


### PR DESCRIPTION
## Summary
- wrap latex bases containing superscripts in helper printing paths
- guard folded fractional power latex to brace existing superscripts
- add regression coverage for Bd/Fd power rendering (#134)

## Testing
- PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test sympy/physics/tests/test_secondquant.py
- PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test code_quality