### PR TITLE
codegen.ast String: positional args invariance [swev-id: sympy__sympy-22456]

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -132,6 +132,7 @@ from collections import defaultdict
 
 from sympy.core.relational import (Ge, Gt, Le, Lt)
 from sympy.core import Symbol, Tuple, Dummy
+from sympy.core.symbol import Str
 from sympy.core.basic import Basic
 from sympy.core.expr import Expr
 from sympy.core.numbers import Float, Integer, oo
@@ -895,11 +896,21 @@ class String(Token):
 
     """
     __slots__ = ('text',)
-    not_in_args = ['text']
     is_Atom = True
+
+    def __new__(cls, text):
+        if isinstance(text, cls):
+            return text
+
+        normalized_text = cls._construct_text(text)
+        obj = CodegenAST.__new__(cls, Str(normalized_text))
+        obj.text = normalized_text
+        return obj
 
     @classmethod
     def _construct_text(cls, text):
+        if isinstance(text, Str):
+            text = text.name
         if not isinstance(text, str):
             raise TypeError("Argument text is not a string type.")
         return text

--- a/sympy/codegen/tests/test_ast_args_invariance.py
+++ b/sympy/codegen/tests/test_ast_args_invariance.py
@@ -1,0 +1,24 @@
+from sympy.core.basic import Basic
+from sympy.core.symbol import Str
+
+from sympy.codegen.ast import String, QuotedString, Comment
+
+
+def _assert_positional_invariance(expr, expected_text):
+    assert expr.text == expected_text
+    assert isinstance(expr.text, str)
+    assert expr.args == (Str(expected_text),)
+    assert isinstance(expr.args[0], Basic)
+    assert expr.func(*expr.args) == expr
+
+
+def test_String_args_are_positional_and_basic():
+    _assert_positional_invariance(String('foo'), 'foo')
+
+
+def test_QuotedString_args_are_positional_and_basic():
+    _assert_positional_invariance(QuotedString('bar'), 'bar')
+
+
+def test_Comment_args_are_positional_and_basic():
+    _assert_positional_invariance(Comment('baz'), 'baz')


### PR DESCRIPTION
## Summary
- store Str arguments for String and subclasses to maintain positional invariance
- keep `.text` as a Python string while accepting Str during reconstruction
- add regression coverage for String, QuotedString, and Comment

## Testing
- pytest sympy/codegen/tests/test_ast_args_invariance.py -q
- pytest sympy/codegen/tests/test_ast.py -q
- bin/test code_quality

Resolves #138