### PR TITLE
Fix lambdify singleton Python tuple codegen (trailing comma) [swev-id: sympy__sympy-23262]

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -956,12 +956,17 @@ def _recursive_to_string(doprint, arg):
         return doprint(arg)
     elif iterable(arg):
         if isinstance(arg, list):
-            left, right = "[]"
+            elements = [_recursive_to_string(doprint, e) for e in arg]
+            return "[" + ', '.join(elements) + "]"
         elif isinstance(arg, tuple):
-            left, right = "()"
+            elements = [_recursive_to_string(doprint, e) for e in arg]
+            if not elements:
+                return "()"
+            if len(elements) == 1:
+                return "(" + elements[0] + ",)"
+            return "(" + ', '.join(elements) + ")"
         else:
             raise NotImplementedError("unhandled type: %s, %s" % (type(arg), arg))
-        return left +', '.join(_recursive_to_string(doprint, e) for e in arg) + right
     elif isinstance(arg, str):
         return arg
     else:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -84,6 +84,27 @@ def test_list_args():
     assert f(1, 2) == 3
 
 
+def test_python_tuple_singleton_trailing_comma():
+    f = lambdify([], tuple([1]))
+    source = inspect.getsource(f)
+    assert "return (1,)" in source
+    assert f() == (1,)
+
+
+def test_python_tuple_multi_element_source():
+    f = lambdify([], (1, 2))
+    source = inspect.getsource(f)
+    assert "return (1, 2)" in source
+    assert f() == (1, 2)
+
+
+def test_python_tuple_nested_sequences():
+    f = lambdify([], ([1], (2,)))
+    source = inspect.getsource(f)
+    assert "return ([1], (2,))" in source
+    assert f() == ([1], (2,))
+
+
 def test_nested_args():
     f1 = lambdify([[w, x]], [w, x])
     assert f1([91, 2]) == [91, 2]


### PR DESCRIPTION
## Summary
- ensure python tuples generated by _recursive_to_string include trailing comma for singletons
- keep multi-element tuples unchanged and cover nested sequences
- add regression tests capturing source output and runtime results

## Testing
- PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test sympy/utilities/tests/test_lambdify.py
- PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test code_quality

Fixes #145