### PR TITLE
fix(symbols): propagate cls through nested sequences for ranges (swev-id: sympy__sympy-23534)

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -791,7 +791,7 @@ def symbols(names, *, cls=Symbol, **args) -> Any:
         return tuple(result)
     else:
         for name in names:
-            result.append(symbols(name, **args))
+            result.append(symbols(name, cls=cls, **args))
 
         return type(names)(result)
 

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -1,5 +1,6 @@
 from sympy.core.numbers import (I, Rational, pi)
 from sympy.core.relational import (GreaterThan, LessThan, StrictGreaterThan, StrictLessThan)
+from sympy.core.function import Function, UndefinedFunction
 from sympy.core.symbol import (Dummy, Symbol, Wild, symbols)
 from sympy.core.sympify import sympify  # can't import as S yet
 from sympy.core.symbol import uniquely_named_symbol, _symbol, Str
@@ -325,6 +326,41 @@ def test_symbols():
     raises(ValueError, lambda: symbols('a::'))
     raises(ValueError, lambda: symbols(':a:'))
     raises(ValueError, lambda: symbols('::a'))
+
+
+def test_symbols_cls_function_nested_ranges():
+    funcs = symbols(("q:2", "u:2"), cls=Function)
+
+    assert funcs == (
+        (Function("q0"), Function("q1")),
+        (Function("u0"), Function("u1")),
+    )
+    assert all(isinstance(f, UndefinedFunction) for group in funcs for f in group)
+
+
+def test_symbols_cls_function_mixed_nested_containers():
+    nested = symbols((["q:2", "phi"], ("u:2", "psi")), cls=Function)
+
+    list_group, tuple_group = nested
+    q_range, phi = list_group
+    u_range, psi = tuple_group
+
+    assert tuple(func.__name__ for func in q_range) == ("q0", "q1")
+    assert phi.__name__ == "phi"
+    assert tuple(func.__name__ for func in u_range) == ("u0", "u1")
+    assert psi.__name__ == "psi"
+    groups = (q_range, (phi,), u_range, (psi,))
+    assert all(isinstance(f, UndefinedFunction) for group in groups for f in group)
+
+
+def test_symbols_cls_symbol_nested_containers_regression():
+    syms = symbols(("q:2", "u:2"), cls=Symbol)
+
+    assert syms == (
+        (Symbol("q0"), Symbol("q1")),
+        (Symbol("u0"), Symbol("u1")),
+    )
+    assert all(isinstance(s, Symbol) for group in syms for s in group)
 
 
 def test_symbols_become_functions_issue_3539():


### PR DESCRIPTION
## Summary
- propagate the cls argument when symbols recurses into nested sequences
- add regression coverage for Function ranges, mixed containers, and Symbol compatibility
- document the original failure output for sympy/core/tests/test_symbol.py

## Reproduction
- on sympy__sympy-23534 run
  ```bash
  python - <<'PY'
  from sympy import Function, symbols
  val = symbols(("q:2", "u:2"), cls=Function)
  print(type(val[0][0]).__name__)
  print(type(val[1][0]).__name__)
  PY
  ```
- observed output
  ```
  Symbol
  Symbol
  ```

## Testing
- PATH=/root/.local/bin:$PATH PYTHONPATH=/workspace/sympy bin/test sympy/core/tests/test_symbol.py
- PATH=/root/.local/bin:$PATH PYTHONPATH=/workspace/sympy bin/test code_quality

Fixes #146