### PR TITLE
Fix kahane_simplify leading free order reversal (swev-id: sympy__sympy-23824)

### DIFF
--- a/sympy/physics/hep/gamma_matrices.py
+++ b/sympy/physics/hep/gamma_matrices.py
@@ -694,8 +694,10 @@ def kahane_simplify(expression):
 
     # If `first_dum_pos` is not zero, it means that there are trailing free gamma
     # matrices in front of `expression`, so multiply by them:
-    for i in range(0, first_dum_pos):
-        [ri.insert(0, free_pos[i]) for ri in resulting_indices]
+    if first_dum_pos:
+        prefix = [free_pos[i] for i in range(first_dum_pos)]
+        for ri in resulting_indices:
+            ri[0:0] = prefix
 
     resulting_expr = S.Zero
     for i in resulting_indices:

--- a/sympy/physics/hep/tests/test_gamma_matrices.py
+++ b/sympy/physics/hep/tests/test_gamma_matrices.py
@@ -262,6 +262,23 @@ def test_kahane_simplify1():
     assert r.equals(-2*G(sigma)*G(rho)*G(nu))
 
 
+def test_kahane_simplify_leading_free_order():
+    mu, rho, sigma = tensor_indices('mu, rho, sigma', LorentzIndex)
+    t1 = G(mu)*G(-mu)*G(rho)*G(sigma)
+    r1 = kahane_simplify(t1)
+    assert r1.equals(4*G(rho)*G(sigma))
+    t2 = G(rho)*G(sigma)*G(mu)*G(-mu)
+    r2 = kahane_simplify(t2)
+    assert r2.equals(4*G(rho)*G(sigma))
+
+
+def test_kahane_simplify_multiple_leading_free_order():
+    alpha, beta, rho, sigma, mu = tensor_indices('alpha, beta, rho, sigma, mu', LorentzIndex)
+    t = G(alpha)*G(beta)*G(mu)*G(-mu)*G(rho)*G(sigma)
+    r = kahane_simplify(t)
+    assert r.equals(4*G(alpha)*G(beta)*G(rho)*G(sigma))
+
+
 def test_gamma_matrix_class():
     i, j, k = tensor_indices('i,j,k', LorentzIndex)
 


### PR DESCRIPTION
## Summary
- preserve the original ordering when re-prepending leading free gamma matrices in `kahane_simplify`
- add regression coverage for single and multiple leading free gamma matrices

## Issue
- Closes #150

## Reproduction
```python
import sympy
from sympy.physics.hep.gamma_matrices import GammaMatrix as G, gamma_trace, LorentzIndex
from sympy.physics.hep.gamma_matrices import kahane_simplify
from sympy.tensor.tensor import tensor_indices

mu, nu, rho, sigma = tensor_indices("mu, nu, rho, sigma", LorentzIndex)

t = G(mu)*G(-mu)*G(rho)*G(sigma)
r = kahane_simplify(t)
print(r)
assert r.equals(4*G(rho)*G(sigma))

t = G(rho)*G(sigma)*G(mu)*G(-mu)
r = kahane_simplify(t)
print(r)
assert r.equals(4*G(rho)*G(sigma))
```

Observed output before this fix:
```
4*GammaMatrix(rho)*GammaMatrix(sigma)
4*GammaMatrix(sigma)*GammaMatrix(rho)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "test_kahane_leading_gamma_matrix_bug.py", line 15, in <module>
    assert r.equals(4*G(rho)*G(sigma))
AssertionError
```

## Testing
- `PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH python -m pytest sympy/physics/hep/tests/test_gamma_matrices.py -k kahane_simplify`