### PR TITLE
swev-id: sympy__sympy-24066 fix dimensionless exponent handling in Add

### DIFF
--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -13,7 +13,7 @@ from sympy.integrals.integrals import integrate
 from sympy.physics.units import (amount_of_substance, area, convert_to, find_unit,
                                  volume, kilometer, joule, molar_gas_constant,
                                  vacuum_permittivity, elementary_charge, volt,
-                                 ohm)
+                                 ohm, farad)
 from sympy.physics.units.definitions import (amu, au, centimeter, coulomb,
     day, foot, grams, hour, inch, kg, km, m, meter, millimeter,
     minute, quart, s, second, speed_of_light, bit,
@@ -193,6 +193,17 @@ def test_check_unit_consistency():
     raises(ValueError, lambda: check_unit_consistency(u + 1))
     raises(ValueError, lambda: check_unit_consistency(u - 1))
     raises(ValueError, lambda: check_unit_consistency(1 - exp(u / w)))
+
+
+def test_dimensionless_exponent_in_add():
+    expr = second / (ohm * farad)
+    factor, dim = SI._collect_factor_and_dimension(100 + exp(expr))
+    assert SI.get_dimension_system().is_dimensionless(dim)
+
+
+def test_dimension_mismatch_in_add_raises():
+    with raises(ValueError):
+        SI._collect_factor_and_dimension(second + ohm)
 
 
 def test_mul_div():

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -175,7 +175,7 @@ class UnitSystem(_QuantityMapper):
             for addend in expr.args[1:]:
                 addend_factor, addend_dim = \
                     self._collect_factor_and_dimension(addend)
-                if dim != addend_dim:
+                if not self.get_dimension_system().equivalent_dims(dim, addend_dim):
                     raise ValueError(
                         'Dimension of "{}" is {}, '
                         'but it should be {}'.format(


### PR DESCRIPTION
## Summary
- use DimensionSystem.equivalent_dims when comparing Add argument dimensions in UnitSystem._collect_factor_and_dimension
- add regression coverage ensuring exp(second/(ohm*farad)) remains dimensionless inside additive expressions
- add a negative test that still raises for non-equivalent dimensions

## Issue
- Closes #154

## Reproduction
```python
from sympy import exp
from sympy.physics import units
from sympy.physics.units.systems.si import SI

expr = units.second / (units.ohm * units.farad)
dim = SI._collect_factor_and_dimension(expr)[1]

assert SI.get_dimension_system().is_dimensionless(dim)

buggy_expr = 100 + exp(expr)
SI._collect_factor_and_dimension(buggy_expr)
```

```
Traceback (most recent call last):
  File "<stdin>", line 11, in <module>
  File "/workspace/sympy/sympy/physics/units/unitsystem.py", line 179, in _collect_factor_and_dimension
    raise ValueError(
ValueError: Dimension of "exp(second/(farad*ohm))" is Dimension(time/(capacitance*impedance)), but it should be Dimension(1)
```

## Testing
- `PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:/root/.nix-profile/bin:$PATH bin/test sympy/physics/units/tests/test_quantities.py`

CI should remain skipped; local tests above passed.