### PR TITLE
swev-id: sympy__sympy-24443 fix permutation homomorphism inverses

### DIFF
--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -308,16 +308,47 @@ def homomorphism(domain, codomain, gens, images=(), check=True):
     return GroupHomomorphism(domain, codomain, images)
 
 def _check_homomorphism(domain, codomain, images):
+    gens = None
+    sym_to_perm = None
+    is_perm_domain = isinstance(domain, PermutationGroup)
+
     if hasattr(domain, 'relators'):
         rels = domain.relators
+        if hasattr(domain, 'generators'):
+            gens = domain.generators
     else:
-        gens = domain.presentation().generators
-        rels = domain.presentation().relators
+        pres = domain.presentation()
+        gens = pres.generators
+        rels = pres.relators
+        if is_perm_domain:
+            domain_gens = domain.generators
+            if len(gens) != len(domain_gens):
+                raise ValueError("PermutationGroup presentation generators do not align with domain generators")
+            sym_to_perm = {}
+            for idx, gen in enumerate(gens):
+                gen_form = gen.array_form
+                if not gen_form:
+                    raise ValueError("PermutationGroup presentation contains empty generator")
+                sym = gen_form[0][0]
+                sym_to_perm[sym] = domain_gens[idx]
     identity = codomain.identity
 
     def _image(r):
         if r.is_identity:
             return identity
+        if sym_to_perm is not None:
+            w = identity
+            for sym, power in r.array_form:
+                try:
+                    generator = sym_to_perm[sym]
+                except KeyError as exc:
+                    raise ValueError(
+                        "Unexpected generator symbol %s in PermutationGroup relator" % sym
+                    ) from exc
+                if generator not in images:
+                    raise ValueError("Image for generator %s not provided" % generator)
+                w = w*images[generator]**power
+            return w
         else:
             w = identity
             r_arr = r.array_form
@@ -333,7 +364,7 @@ def _check_homomorphism(domain, codomain, images):
             # both indices
             while i < len(r):
                 power = r_arr[j][1]
-                if isinstance(domain, PermutationGroup) and r[i] in gens:
+                if isinstance(domain, PermutationGroup) and gens is not None and r[i] in gens:
                     s = domain.generators[gens.index(r[i])]
                 else:
                     s = r[i]

--- a/sympy/combinatorics/tests/test_homomorphisms.py
+++ b/sympy/combinatorics/tests/test_homomorphisms.py
@@ -3,7 +3,7 @@ from sympy.combinatorics.perm_groups import PermutationGroup
 from sympy.combinatorics.homomorphisms import homomorphism, group_isomorphism, is_isomorphic
 from sympy.combinatorics.free_groups import free_group
 from sympy.combinatorics.fp_groups import FpGroup
-from sympy.combinatorics.named_groups import AlternatingGroup, DihedralGroup, CyclicGroup
+from sympy.combinatorics.named_groups import AlternatingGroup, DihedralGroup, CyclicGroup, SymmetricGroup
 from sympy.testing.pytest import raises
 
 def test_homomorphism():
@@ -107,3 +107,17 @@ def test_check_homomorphism():
     b = Permutation(1,3)
     G = PermutationGroup([a, b])
     raises(ValueError, lambda: homomorphism(G, G, [a], [a]))
+
+
+def test_permutation_group_homomorphism_regressions():
+    D3 = DihedralGroup(3)
+    T = homomorphism(D3, D3, D3.generators, D3.generators)
+    assert T.is_isomorphism()
+
+    S3 = SymmetricGroup(3)
+    id_s3 = homomorphism(S3, S3, S3.generators, S3.generators)
+    assert id_s3.is_isomorphism()
+
+    A4 = AlternatingGroup(4)
+    id_a4 = homomorphism(A4, A4, A4.generators, A4.generators)
+    assert id_a4.is_isomorphism()


### PR DESCRIPTION
## Summary
- align PermutationGroup relator evaluation with presentation symbols
- evaluate relators via mapped generator images to respect inverses
- add regression tests for DihedralGroup(3) and identity homomorphisms on S3/A4

## Testing
- PYTHONPATH=/nix/store/12f1jfj4mxz1f9xjk4lbhsfn7i9s7v7g-python3.11-mpmath-1.3.0/lib/python3.11/site-packages PATH=/root/.local/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin python3 -m pytest sympy/combinatorics/tests/test_homomorphisms.py -q
- PYTHONPATH=/nix/store/12f1jfj4mxz1f9xjk4lbhsfn7i9s7v7g-python3.11-mpmath-1.3.0/lib/python3.11/site-packages:/workspace/sympy PATH=/root/.local/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin bin/test code_quality

Resolves #159.