### PR TITLE
swev-id: sympy__sympy-24539 Fix PolyElement.as_expr symbol handling

### DIFF
--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -616,8 +616,9 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
             return new_ring.from_dict(self, self.ring.domain)
 
     def as_expr(self, *symbols):
-        if symbols and len(symbols) != self.ring.ngens:
-            raise ValueError("not enough symbols, expected %s got %s" % (self.ring.ngens, len(symbols)))
+        if symbols:
+            if len(symbols) != self.ring.ngens:
+                raise ValueError("expected %s symbols, got %s" % (self.ring.ngens, len(symbols)))
         else:
             symbols = self.ring.symbols
 

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -257,13 +257,15 @@ def test_PolyElement_as_expr():
     g = 3*X**2*Y - X*Y*Z + 7*Z**3 + 1
 
     assert f != g
-    assert f.as_expr() == g
 
-    X, Y, Z = symbols("x,y,z")
-    g = 3*X**2*Y - X*Y*Z + 7*Z**3 + 1
+    default_expr = f.as_expr()
+    assert default_expr == g
+    assert default_expr.free_symbols == set(R.symbols)
 
-    assert f != g
-    assert f.as_expr(X, Y, Z) == g
+    U, V, W = symbols('U, V, W')
+    provided_expr = f.as_expr(U, V, W)
+    assert provided_expr == 3*U**2*V - U*V*W + 7*W**3 + 1
+    assert provided_expr.free_symbols == {U, V, W}
 
     raises(ValueError, lambda: f.as_expr(X))
 


### PR DESCRIPTION
## Summary
- ensure PolyElement.as_expr respects provided symbols when arity matches
- default to ring symbols only when no overrides are given
- cover expected and error paths with targeted tests

## Reproduction Steps
```python
from sympy import ring, ZZ, symbols
R, x, y, z = ring("x,y,z", ZZ)
f = 3*x**2*y - x*y*z + 7*z**3 + 1
U, V, W = symbols("u,v,w")
f.as_expr(U, V, W)
```

## Observed Failure
- Returned expression ignored the supplied `U, V, W` symbols and used `x, y, z` instead.

## Expected Behavior
- `as_expr(U, V, W)` should substitute the provided symbol tuple when the arity matches, and fall back to ring symbols only when none are supplied.

Fixes #160