### PR TITLE
swev-id: sympy__sympy-24562 fix(core): normalize two-arg Rational inputs

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1625,19 +1625,14 @@ class Rational(Number):
             q = 1
             gcd = 1
 
-        if not isinstance(p, SYMPY_INTS):
-            p = Rational(p)
-            q *= p.q
-            p = p.p
-        else:
+        if isinstance(p, SYMPY_INTS) and isinstance(q, SYMPY_INTS):
             p = int(p)
-
-        if not isinstance(q, SYMPY_INTS):
-            q = Rational(q)
-            p *= q.q
-            q = q.p
-        else:
             q = int(q)
+        else:
+            rp = Rational(p)
+            rq = Rational(q)
+            p = rp.p * rq.q
+            q = rp.q * rq.p
 
         # p and q are now ints
         if q == 0:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -370,6 +370,37 @@ def test_Rational_new():
     assert n.p == -2
 
 
+def test_rational_two_argument_construction_mixed_types():
+    target = Rational(1, 200)
+
+    assert Rational("0.5", "100") == target
+    assert Rational(0.5, 100) == target
+    assert Rational("0.5/100") == target
+    assert Rational("0.5") / Rational("100") == target
+
+    assert Rational("0.5", 100) == target
+    assert Rational(0.5, "100") == target
+    assert Rational(Rational(1, 2), "100") == target
+
+    assert Rational("3/4", "2") == Rational(3, 8)
+    assert Rational("1", "3/4") == Rational(4, 3)
+    assert Rational("1e-2", "100") == Rational(1, 10000)
+
+    assert Rational("-0.5", "100") == Rational(-1, 200)
+    assert Rational("0.5", "-100") == Rational(-1, 200)
+    assert Rational("-0.5", "-100") == target
+
+    property_pairs = [
+        (0.5, 100),
+        ("0.5", "100"),
+        ("1e-2", "100"),
+    ]
+    for p, q in property_pairs:
+        r = Rational(p, q)
+        assert r == Rational(f"{p}/{q}")
+        assert r == Rational(p) / Rational(q)
+
+
 def test_Number_new():
     """"
     Test for Number constructor


### PR DESCRIPTION
## Summary
- normalize Rational(p, q) when mixed types by converting operands to Rational and cross-multiplying, keeping integer fast path intact
- add regression tests covering strings, floats, rationals, scientific notation, and sign normalization scenarios

## Testing
- PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test sympy/core/tests/test_numbers.py
- PYTHONPATH=/workspace/sympy PATH=/root/.local/bin:$PATH bin/test code_quality

Fixes #162