### PR TITLE
swev-id: sympy__sympy-24661 fix evaluate=False relational parsing

### DIFF
--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -10,7 +10,7 @@ from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin)
-from sympy.logic.boolalg import (false, Or, true, Xor)
+from sympy.logic.boolalg import (false, Or, true, Xor, And)
 from sympy.matrices.dense import Matrix
 from sympy.parsing.sympy_parser import null
 from sympy.polys.polytools import Poly
@@ -30,6 +30,7 @@ from sympy.abc import _clash, _clash1, _clash2
 from sympy.external.gmpy import HAS_GMPY
 from sympy.sets import FiniteSet, EmptySet
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
+from sympy.core.relational import Eq, Lt, Ge
 
 import mpmath
 from collections import defaultdict, OrderedDict
@@ -441,6 +442,27 @@ def test_evaluate_false():
     }
     for case, result in cases.items():
         assert sympify(case, evaluate=False) == result
+
+
+def test_sympify_relational_evaluate_false():
+    rel = sympify('1 < 2', evaluate=False)
+    assert rel == Lt(1, 2, evaluate=False)
+
+    assert sympify('1 < 2') is true
+
+    assert sympify('1 >= 2', evaluate=False) == Ge(1, 2, evaluate=False)
+
+    chained = sympify('1 < x < 3', evaluate=False)
+    expected = And(
+        Lt(1, x, evaluate=False),
+        Lt(x, 3, evaluate=False),
+        evaluate=False
+    )
+    assert chained == expected
+
+    assert sympify('Eq(1, 2)', evaluate=False) == Eq(1, 2, evaluate=False)
+
+    raises(TypeError, lambda: sympify('1 < x < 3'))
 
 
 def test_issue_4133():

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1117,7 +1117,31 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         'cos', 'cot', 'csc', 'sec', 'sin', 'tan',
         'cosh', 'coth', 'csch', 'sech', 'sinh', 'tanh',
         'exp', 'ln', 'log', 'sqrt', 'cbrt',
+        'Eq', 'Ne', 'Lt', 'Le', 'Gt', 'Ge', 'And',
     )
+    comparison_operators = {
+        ast.Eq: 'Eq',
+        ast.NotEq: 'Ne',
+        ast.Lt: 'Lt',
+        ast.LtE: 'Le',
+        ast.Gt: 'Gt',
+        ast.GtE: 'Ge',
+    }
+
+    def _evaluate_false_keyword(self):
+        return ast.keyword(
+            arg='evaluate',
+            value=ast.NameConstant(value=False, ctx=ast.Load())
+        )
+
+    def _make_call(self, func_name, args):
+        return ast.Call(
+            func=ast.Name(id=func_name, ctx=ast.Load()),
+            args=args,
+            keywords=[self._evaluate_false_keyword()],
+            starargs=None,
+            kwargs=None
+        )
 
     def flatten(self, args, func):
         result = []
@@ -1185,6 +1209,25 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
 
             return new_node
         return node
+
+    def visit_Compare(self, node):
+        if any(op.__class__ not in self.comparison_operators for op in node.ops):
+            return self.generic_visit(node)
+
+        left = self.visit(node.left)
+        comparators = [self.visit(comp) for comp in node.comparators]
+        relational_names = [self.comparison_operators[op.__class__] for op in node.ops]
+
+        if len(node.ops) == 1:
+            return self._make_call(relational_names[0], [left, comparators[0]])
+
+        calls = []
+        current_left = left
+        for func_name, right in zip(relational_names, comparators):
+            calls.append(self._make_call(func_name, [current_left, right]))
+            current_left = right
+
+        return self._make_call('And', calls)
 
     def visit_Call(self, node):
         new_node = self.generic_visit(node)

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -6,7 +6,7 @@ import builtins
 import types
 
 from sympy.assumptions import Q
-from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow, Eq
+from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow, Eq, Lt, Ge
 from sympy.functions import exp, factorial, factorial2, sin, Min, Max
 from sympy.logic import And
 from sympy.series import Limit
@@ -216,6 +216,26 @@ def test_issue_10773():
     }
     for text, result in inputs.items():
         assert parse_expr(text, evaluate=False) == parse_expr(result, evaluate=False)
+
+
+def test_parse_expr_inequalities_evaluate_false():
+    x = Symbol('x')
+
+    assert parse_expr('1 < 2') == True
+    assert parse_expr('1 < 2', evaluate=False) == Lt(1, 2, evaluate=False)
+    assert parse_expr('1 >= 2', evaluate=False) == Ge(1, 2, evaluate=False)
+
+    chained = parse_expr('1 < x < 3', evaluate=False)
+    expected = And(
+        Lt(1, x, evaluate=False),
+        Lt(x, 3, evaluate=False),
+        evaluate=False
+    )
+    assert chained == expected
+
+    assert parse_expr('Eq(1, 2)', evaluate=False) == Eq(1, 2, evaluate=False)
+
+    raises(TypeError, lambda: parse_expr('1 < x < 3'))
 
 
 def test_split_symbols():


### PR DESCRIPTION
## Summary
- ensure EvaluateFalseTransformer emits unevaluated relationals for comparisons when evaluate=False, including chaining into And(evaluate=False)
- extend evaluate=False injection to Eq/Ne/Lt/Le/Gt/Ge/And and add parser & sympify coverage
- Fixes #166

## Testing
- PYTHONPATH=. PATH=/root/.local/bin:$PATH python -m pytest sympy/parsing/tests/test_sympy_parser.py::test_parse_expr_inequalities_evaluate_false -q
- PYTHONPATH=. PATH=/root/.local/bin:$PATH python -m pytest sympy/core/tests/test_sympify.py::test_sympify_relational_evaluate_false -q
- PATH=/root/.local/bin:$PATH bin/test code_quality

## Reproduction
Before fix:
```
$ PYTHONPATH=. python - <<'EOF'
from sympy.parsing.sympy_parser import parse_expr
expr = parse_expr('1 < 2', evaluate=False)
print(expr)
print(type(expr))
EOF
True
<class 'sympy.logic.boolalg.BooleanTrue'>
```

After fix:
```
$ PYTHONPATH=. python - <<'EOF'
from sympy.parsing.sympy_parser import parse_expr
from sympy import Lt
expr = parse_expr('1 < 2', evaluate=False)
print(expr)
print(expr == Lt(1, 2, evaluate=False))
EOF
1 < 2
True
```