### PR TITLE
swev-id: sympy__sympy-13091 Return NotImplemented for unsupported comparisons

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -313,7 +313,7 @@ class Basic(with_metaclass(ManagedProperties)):
             try:
                 other = _sympify(other)
             except SympifyError:
-                return False    # sympy != other
+                return NotImplemented
 
             if type(self) != type(other):
                 return False
@@ -329,7 +329,10 @@ class Basic(with_metaclass(ManagedProperties)):
 
            but faster
         """
-        return not self.__eq__(other)
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return not result
 
     def dummy_eq(self, other, symbol=None):
         """

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1253,12 +1253,12 @@ class Float(Number):
             try:
                 ompf = o._as_mpf_val(self._prec)
             except ValueError:
-                return False
+                return NotImplemented
             return bool(mlib.mpf_eq(self._mpf_, ompf))
         try:
             other = _sympify(other)
         except SympifyError:
-            return False    # sympy != other  -->  not ==
+            return NotImplemented
         if isinstance(other, NumberSymbol):
             if other.is_irrational:
                 return False
@@ -1276,7 +1276,10 @@ class Float(Number):
         return False    # Float != non-Number
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return not result
 
     def __gt__(self, other):
         try:
@@ -1719,7 +1722,7 @@ class Rational(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            return False    # sympy != other  -->  not ==
+            return NotImplemented
         if isinstance(other, NumberSymbol):
             if other.is_irrational:
                 return False
@@ -1734,7 +1737,10 @@ class Rational(Number):
         return False
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return not result
 
     def __gt__(self, other):
         try:
@@ -2112,7 +2118,10 @@ class Integer(Rational):
         return Rational.__eq__(self, other)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return not result
 
     def __gt__(self, other):
         try:
@@ -3339,7 +3348,7 @@ class NumberSymbol(AtomicExpr):
         try:
             other = _sympify(other)
         except SympifyError:
-            return False    # sympy != other  -->  not ==
+            return NotImplemented
         if self is other:
             return True
         if isinstance(other, Number) and self.is_irrational:
@@ -3348,7 +3357,10 @@ class NumberSymbol(AtomicExpr):
         return False    # NumberSymbol != non-(Number|self)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return NotImplemented
+        return not result
 
     def __lt__(self, other):
         try:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1285,7 +1285,7 @@ class Float(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s > %s" % (self, other))
+            return NotImplemented
         if isinstance(other, NumberSymbol):
             return other.__le__(self)
         if other.is_comparable:
@@ -1299,7 +1299,7 @@ class Float(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s >= %s" % (self, other))
+            return NotImplemented
         if isinstance(other, NumberSymbol):
             return other.__lt__(self)
         if other.is_comparable:
@@ -1313,7 +1313,7 @@ class Float(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s < %s" % (self, other))
+            return NotImplemented
         if isinstance(other, NumberSymbol):
             return other.__ge__(self)
         if other.is_real and other.is_number:
@@ -1327,7 +1327,7 @@ class Float(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s <= %s" % (self, other))
+            return NotImplemented
         if isinstance(other, NumberSymbol):
             return other.__gt__(self)
         if other.is_real and other.is_number:
@@ -1746,7 +1746,7 @@ class Rational(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s > %s" % (self, other))
+            return NotImplemented
         if isinstance(other, NumberSymbol):
             return other.__le__(self)
         expr = self
@@ -1764,7 +1764,7 @@ class Rational(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s >= %s" % (self, other))
+            return NotImplemented
         if isinstance(other, NumberSymbol):
             return other.__lt__(self)
         expr = self
@@ -1782,7 +1782,7 @@ class Rational(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s < %s" % (self, other))
+            return NotImplemented
         if isinstance(other, NumberSymbol):
             return other.__ge__(self)
         expr = self
@@ -1800,7 +1800,7 @@ class Rational(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s <= %s" % (self, other))
+            return NotImplemented
         expr = self
         if isinstance(other, NumberSymbol):
             return other.__gt__(self)
@@ -2127,7 +2127,7 @@ class Integer(Rational):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s > %s" % (self, other))
+            return NotImplemented
         if isinstance(other, Integer):
             return _sympify(self.p > other.p)
         return Rational.__gt__(self, other)
@@ -2136,7 +2136,7 @@ class Integer(Rational):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s < %s" % (self, other))
+            return NotImplemented
         if isinstance(other, Integer):
             return _sympify(self.p < other.p)
         return Rational.__lt__(self, other)
@@ -2145,7 +2145,7 @@ class Integer(Rational):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s >= %s" % (self, other))
+            return NotImplemented
         if isinstance(other, Integer):
             return _sympify(self.p >= other.p)
         return Rational.__ge__(self, other)
@@ -2154,7 +2154,7 @@ class Integer(Rational):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s <= %s" % (self, other))
+            return NotImplemented
         if isinstance(other, Integer):
             return _sympify(self.p <= other.p)
         return Rational.__le__(self, other)
@@ -2849,7 +2849,7 @@ class Infinity(with_metaclass(Singleton, Number)):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s < %s" % (self, other))
+            return NotImplemented
         if other.is_real:
             return S.false
         return Expr.__lt__(self, other)
@@ -2858,7 +2858,7 @@ class Infinity(with_metaclass(Singleton, Number)):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s <= %s" % (self, other))
+            return NotImplemented
         if other.is_real:
             if other.is_finite or other is S.NegativeInfinity:
                 return S.false
@@ -2872,7 +2872,7 @@ class Infinity(with_metaclass(Singleton, Number)):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s > %s" % (self, other))
+            return NotImplemented
         if other.is_real:
             if other.is_finite or other is S.NegativeInfinity:
                 return S.true
@@ -2886,7 +2886,7 @@ class Infinity(with_metaclass(Singleton, Number)):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s >= %s" % (self, other))
+            return NotImplemented
         if other.is_real:
             return S.true
         return Expr.__ge__(self, other)
@@ -3070,7 +3070,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s < %s" % (self, other))
+            return NotImplemented
         if other.is_real:
             if other.is_finite or other is S.Infinity:
                 return S.true
@@ -3084,7 +3084,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s <= %s" % (self, other))
+            return NotImplemented
         if other.is_real:
             return S.true
         return Expr.__le__(self, other)
@@ -3093,7 +3093,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s > %s" % (self, other))
+            return NotImplemented
         if other.is_real:
             return S.false
         return Expr.__gt__(self, other)
@@ -3102,7 +3102,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s >= %s" % (self, other))
+            return NotImplemented
         if other.is_real:
             if other.is_finite or other is S.Infinity:
                 return S.false
@@ -3366,7 +3366,7 @@ class NumberSymbol(AtomicExpr):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s < %s" % (self, other))
+            return NotImplemented
         if self is other:
             return S.false
         if isinstance(other, Number):
@@ -3387,7 +3387,7 @@ class NumberSymbol(AtomicExpr):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s <= %s" % (self, other))
+            return NotImplemented
         if self is other:
             return S.true
         if other.is_real and other.is_number:
@@ -3400,7 +3400,7 @@ class NumberSymbol(AtomicExpr):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s > %s" % (self, other))
+            return NotImplemented
         r = _sympify((-self) < (-other))
         if r in (S.true, S.false):
             return r
@@ -3411,7 +3411,7 @@ class NumberSymbol(AtomicExpr):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s >= %s" % (self, other))
+            return NotImplemented
         r = _sympify((-self) <= (-other))
         if r in (S.true, S.false):
             return r

--- a/sympy/core/tests/test_equal.py
+++ b/sympy/core/tests/test_equal.py
@@ -63,6 +63,28 @@ def test_cmp_bug2():
     assert (Symbol != t)
 
 
+def test_basic_comparison_delegates_to_external():
+    x = Symbol('x')
+
+    class Mirror:
+        def __eq__(self, other):
+            if other == x:
+                return True
+            return NotImplemented
+
+        def __ne__(self, other):
+            if other == x:
+                return False
+            return NotImplemented
+
+    mirror = Mirror()
+
+    assert (mirror == x) is True
+    assert (x == mirror) is True
+    assert (mirror != x) is False
+    assert (x != mirror) is False
+
+
 def test_cmp_issue_4357():
     """ Check that Basic subclasses can be compared with sympifiable objects.
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -24,6 +24,45 @@ def same_and_same_prec(a, b):
     return a == b and a._prec == b._prec
 
 
+def _assert_symmetric_comparison(value):
+    class Mirror:
+        def __init__(self, target):
+            self._target = target
+
+        def __eq__(self, other):
+            if other == self._target:
+                return True
+            return NotImplemented
+
+        def __ne__(self, other):
+            if other == self._target:
+                return False
+            return NotImplemented
+
+    mirror = Mirror(value)
+
+    assert (mirror == value) is True
+    assert (value == mirror) is True
+    assert (mirror != value) is False
+    assert (value != mirror) is False
+
+
+def test_float_comparison_delegates_to_external():
+    _assert_symmetric_comparison(Float('2.5'))
+
+
+def test_rational_comparison_delegates_to_external():
+    _assert_symmetric_comparison(Rational(3, 7))
+
+
+def test_integer_comparison_delegates_to_external():
+    _assert_symmetric_comparison(Integer(5))
+
+
+def test_numbersymbol_comparison_delegates_to_external():
+    _assert_symmetric_comparison(pi)
+
+
 def test_integers_cache():
     python_int = 2**65 + 3175259
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -24,27 +24,65 @@ def same_and_same_prec(a, b):
     return a == b and a._prec == b._prec
 
 
+class _ComparisonMirror:
+    def __init__(self, target):
+        self._target = target
+
+    def _matches(self, other):
+        return other == self._target
+
+    def __eq__(self, other):
+        if self._matches(other):
+            return True
+        return NotImplemented
+
+    def __ne__(self, other):
+        if self._matches(other):
+            return False
+        return NotImplemented
+
+    def __lt__(self, other):
+        if self._matches(other):
+            return True
+        return NotImplemented
+
+    def __le__(self, other):
+        if self._matches(other):
+            return True
+        return NotImplemented
+
+    def __gt__(self, other):
+        if self._matches(other):
+            return False
+        return NotImplemented
+
+    def __ge__(self, other):
+        if self._matches(other):
+            return False
+        return NotImplemented
+
+
 def _assert_symmetric_comparison(value):
-    class Mirror:
-        def __init__(self, target):
-            self._target = target
-
-        def __eq__(self, other):
-            if other == self._target:
-                return True
-            return NotImplemented
-
-        def __ne__(self, other):
-            if other == self._target:
-                return False
-            return NotImplemented
-
-    mirror = Mirror(value)
+    mirror = _ComparisonMirror(value)
 
     assert (mirror == value) is True
     assert (value == mirror) is True
     assert (mirror != value) is False
     assert (value != mirror) is False
+
+
+def _assert_symmetric_ordering(value):
+    mirror = _ComparisonMirror(value)
+
+    assert (mirror < value) is True
+    assert (mirror <= value) is True
+    assert (mirror > value) is False
+    assert (mirror >= value) is False
+
+    assert (value > mirror) is True
+    assert (value >= mirror) is True
+    assert (value < mirror) is False
+    assert (value <= mirror) is False
 
 
 def test_float_comparison_delegates_to_external():
@@ -61,6 +99,30 @@ def test_integer_comparison_delegates_to_external():
 
 def test_numbersymbol_comparison_delegates_to_external():
     _assert_symmetric_comparison(pi)
+
+
+def test_float_ordering_delegates_to_external():
+    _assert_symmetric_ordering(Float('2.5'))
+
+
+def test_rational_ordering_delegates_to_external():
+    _assert_symmetric_ordering(Rational(3, 7))
+
+
+def test_integer_ordering_delegates_to_external():
+    _assert_symmetric_ordering(Integer(5))
+
+
+def test_numbersymbol_ordering_delegates_to_external():
+    _assert_symmetric_ordering(pi)
+
+
+def test_infinity_ordering_delegates_to_external():
+    _assert_symmetric_ordering(oo)
+
+
+def test_negative_infinity_ordering_delegates_to_external():
+    _assert_symmetric_ordering(-oo)
 
 
 def test_integers_cache():


### PR DESCRIPTION
## Summary
- return NotImplemented from Basic equality when sympification fails and guard __ne__ against delegating results
- propagate NotImplemented handling across Float, Rational, Integer, NumberSymbol, Infinity, and NegativeInfinity ordering comparisons
- expand regression tests to cover symmetric equality and ordering delegation against external comparator objects

## Testing
- PYTHONPATH=/workspace/pythoncompat:/workspace/sympy PATH=/root/.local/bin:$PATH pytest sympy/core/tests/test_equal.py
- PYTHONPATH=/workspace/pythoncompat:/workspace/sympy PATH=/root/.local/bin:$PATH pytest sympy/core/tests/test_numbers.py *(fails: sympy.utilities.pytest.XFail: test_mpmath_issues; see Failures)*
- PYTHONPATH=/workspace/pythoncompat:/workspace/sympy PATH=/root/.local/bin:$PATH bin/test sympy/core/tests/test_numbers.py
- PYTHONPATH=/workspace/pythoncompat:/workspace/sympy PATH=/root/.local/bin:$PATH bin/test code_quality

## Failures
- Command: PYTHONPATH=/workspace/pythoncompat:/workspace/sympy PATH=/root/.local/bin:$PATH pytest sympy/core/tests/test_numbers.py
  ```
  TypeError: _normalize() missing 4 required positional arguments: 'exp', 'bc', 'prec', and 'rnd'
  ...
  sympy.utilities.pytest.XFail: test_mpmath_issues
  ```
  Reproduction: run the command above. The failure originates from an XFAIL-marked test; rerun with `bin/test sympy/core/tests/test_numbers.py` to respect SymPy's XFAIL handling.

Fixes #170